### PR TITLE
dreamcast: QSPI-primary VMU storage + SD backup + reliability fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -656,7 +656,7 @@ pico_generate_pio_header(joypad_dc ${CMAKE_CURRENT_LIST_DIR}/native/device/dream
 # USB4Maple-compatible pinout: GPIO 14/15 for Maple Bus
 add_executable(joypad_dc_rp2040zero)
 target_compile_definitions(joypad_dc_rp2040zero PRIVATE
-    CONFIG_DC=1 CONFIG_USB_HOST=1 CONFIG_DC_CORE1_TX=1 CONFIG_VMU=1
+    CONFIG_DC=1 CONFIG_USB_HOST=1 CONFIG_DC_CORE1_TX=1 CONFIG_VMU=1 CONFIG_VMU_QSPI=1 CONFIG_NO_FLASH_LOCKOUT=1
     MAPLE_PIN1=14
     MAPLE_PIN5=15
     WS2812_PIN=16

--- a/src/native/device/dreamcast/dreamcast_device.c
+++ b/src/native/device/dreamcast/dreamcast_device.c
@@ -14,6 +14,7 @@
 // - PIO1 SM3: available for other protocols (e.g., N64 joybus at offset 10)
 
 #include "dreamcast_device.h"
+#include "core/services/leds/leds.h"
 #include "maple_state_machine.h"
 #ifdef CONFIG_VMU
 #include "vmu.h"
@@ -916,6 +917,17 @@ static volatile uint32_t core1_state = 0;  // 0=not started, 1=building, 2=ready
 // Handshake flags (can't use FIFO - it's used by flash_safe_execute lockout)
 static volatile bool core1_ready = false;
 static volatile bool core0_started_pio = false;
+static volatile bool maple_tx_pause = false;  // Set by Core 0 before flash writes
+
+// LED feedback for VMU activity
+#define LED_VMU_IDLE_R      64
+#define LED_VMU_IDLE_G      32
+#define LED_VMU_IDLE_B       0   // Amber — controller connected, idle
+#define LED_VMU_ACTIVE_R     0
+#define LED_VMU_ACTIVE_G     0
+#define LED_VMU_ACTIVE_B    64   // Blue — VMU active (read/write/flush)
+
+uint32_t vmu_led_timeout_ms = 0;  // Non-zero = VMU activity LED active
 
 // Packet notification (can't use FIFO - use ring buffer with volatile indices)
 static volatile uint32_t packet_end_write = 0;  // Written by Core1
@@ -1004,13 +1016,16 @@ static void __no_inline_not_in_flash_func(core1_rx_task)(void)
 
 
                 // Send response immediately via DMA
-                if (NextPacketSend != SEND_NOTHING) {
-                    if (dma_channel_is_busy(tx_dma_channel)) {
-                        tx_busy_count++;
-                    }
-                    if (!dma_channel_is_busy(tx_dma_channel)) {
-                        tx_sent_count++;
-                        switch (NextPacketSend) {
+                // SendPacket() waits for DMA completion internally, so no
+                // need to check dma_channel_is_busy() here — doing so caused
+                // responses to be silently dropped when DMA was busy, which
+                // manifested as intermittent enumeration failures.
+                // maple_tx_pause: Core 0 sets this before flash erase/program
+                // to avoid corrupting an in-flight transmission. Core 1 skips
+                // sending for at most one 16.7ms DC poll frame.
+                if (NextPacketSend != SEND_NOTHING && !maple_tx_pause) {
+                    tx_sent_count++;
+                    switch (NextPacketSend) {
                         case SEND_CONTROLLER_INFO:
                             SendPacket((uint32_t *)pInfoPacket, sizeof(InfoPacket) / sizeof(uint32_t));
                             break;
@@ -1098,7 +1113,6 @@ static void __no_inline_not_in_flash_func(core1_rx_task)(void)
                         default:
                             break;
                         }
-                    }
                     NextPacketSend = SEND_NOTHING;
                 }
 #else
@@ -1286,6 +1300,22 @@ void __not_in_flash_func(dreamcast_core1_task)(void)
     // Never returns
 }
 
+// Returns current Maple Bus RX packet count — increments each time Core 1
+// finishes processing a packet. Used by QSPI backend to detect bus idle:
+// if count hasn't changed since last check, no packet is in flight.
+uint32_t dreamcast_rx_count(void)
+{
+    return rx_ends_count;
+}
+
+// Pause/resume Maple Bus TX — call before/after flash erase+program.
+// Core 1 skips sending responses while paused; the DC retries on the
+// next 16.7ms frame. Keep pause duration under ~10ms to avoid DC dropout.
+void dreamcast_set_maple_pause(bool pause)
+{
+    maple_tx_pause = pause;
+}
+
 // ============================================================================
 // CORE 0 TASK (packet processing and TX)
 // ============================================================================
@@ -1315,13 +1345,68 @@ void dreamcast_task(void)
     // SD card load also deferred here to avoid blocking Maple Bus enumeration at boot
 #ifdef CONFIG_VMU
     if (!vmu_enabled && time_us_32() > vmu_enable_time) {
-        vmu_sd_load();          // Load saved VMU from SD (deferred from boot)
-        dreamcast_enable_vmu(); // Advertise VMU to DC
+        // QSPI is always available so VMU is always advertised.
+        // vmu_sd_load() also sets up SD as backup if a card is present.
+        vmu_sd_load();
+        dreamcast_enable_vmu();
         vmu_enabled = true;
-        printf("[DC] VMU+rumble advertisement enabled (addr 0x23)\n");
+        printf("[DC] VMU+rumble advertisement enabled\n");
     }
 #else
     (void)vmu_enabled; (void)vmu_enable_time;
+#endif
+
+    // VMU LED — driven from Core 0 using volatile flags set by Core 1
+#ifdef CONFIG_VMU
+    extern volatile bool vmu_dirty_flag;
+    extern volatile bool vmu_activity_flag;
+    static bool vmu_led_on = false;
+    static uint32_t vmu_led_blink_ms = 0;
+    static uint32_t vmu_read_flash_ms = 0;  // Brief flash for read activity
+
+    uint32_t vmu_now_ms = to_ms_since_boot(get_absolute_time());
+
+    // Latch activity flag — covers both reads and writes
+    if (vmu_activity_flag) {
+        vmu_activity_flag = false;
+        if (!vmu_dirty_flag) {
+            // Read-only activity — flash blue briefly then return to amber
+            vmu_read_flash_ms = vmu_now_ms + 300;
+        }
+        vmu_led_timeout_ms = 1;
+    }
+
+    if (vmu_dirty_flag) {
+        // Write pending flush — blink blue until flushed
+        vmu_read_flash_ms = 0;  // Cancel any read flash
+        if (vmu_now_ms - vmu_led_blink_ms >= 150) {
+            vmu_led_blink_ms = vmu_now_ms;
+            vmu_led_on = !vmu_led_on;
+            leds_set_color(vmu_led_on ? LED_VMU_ACTIVE_R : 0,
+                           vmu_led_on ? LED_VMU_ACTIVE_G : 0,
+                           vmu_led_on ? LED_VMU_ACTIVE_B : 0);
+        }
+        vmu_led_timeout_ms = 1;
+    } else if (vmu_read_flash_ms != 0) {
+        // Read flash — solid blue briefly
+        leds_set_color(LED_VMU_ACTIVE_R, LED_VMU_ACTIVE_G, LED_VMU_ACTIVE_B);
+        if (vmu_now_ms > vmu_read_flash_ms) {
+            vmu_read_flash_ms = 0;
+            vmu_led_timeout_ms = 0;
+            vmu_led_on = false;
+            leds_set_color(LED_VMU_IDLE_R, LED_VMU_IDLE_G, LED_VMU_IDLE_B);
+        }
+    } else if (vmu_led_timeout_ms != 0) {
+        // Activity done — return to idle
+        vmu_led_timeout_ms = 0;
+        vmu_led_on = false;
+        leds_set_color(LED_VMU_IDLE_R, LED_VMU_IDLE_G, LED_VMU_IDLE_B);
+    }
+
+    // Safety: ensure maple_tx_pause never gets stuck
+    if (maple_tx_pause && !vmu_dirty_flag) {
+        maple_tx_pause = false;
+    }
 #endif
 
     // Periodic debug output (every 5 seconds)

--- a/src/native/device/dreamcast/dreamcast_device.h
+++ b/src/native/device/dreamcast/dreamcast_device.h
@@ -141,6 +141,18 @@ void dreamcast_init(void);
 // Core 1 task (real-time Maple Bus handling)
 void __not_in_flash_func(dreamcast_core1_task)(void);
 
+// Returns current Maple Bus RX packet count (increments each packet Core 1 processes).
+// Use to detect bus idle: if count hasn't changed, no packet is in flight.
+uint32_t dreamcast_rx_count(void);
+
+// Pause/resume Maple Bus TX responses — set before flash erase/program,
+// clear immediately after. Core 1 skips sending while paused; DC retries
+// on next 16.7ms frame. Keep pause under ~10ms to avoid DC dropout.
+void dreamcast_set_maple_pause(bool pause);
+
+// LED timeout — set by VMU activity handlers, cleared by dreamcast_task()
+extern uint32_t vmu_led_timeout_ms;
+
 // Core 0 task (periodic maintenance)
 void dreamcast_task(void);
 

--- a/src/native/device/dreamcast/vmu.c
+++ b/src/native/device/dreamcast/vmu.c
@@ -27,7 +27,8 @@
 // 128KB RAM buffer for VMU image
 // NOTE: RP2040 has 264KB SRAM total — JoypadOS uses ~50KB so this fits
 uint8_t vmu_ram[VMU_TOTAL_BLOCKS * VMU_BLOCK_SIZE];
-volatile bool vmu_dirty_flag = false;  // Set by Core 1, read by Core 0
+volatile bool vmu_dirty_flag = false;    // Set by Core 1, read by Core 0
+volatile bool vmu_activity_flag = false; // Set by Core 1 on any read/write, cleared by Core 0
 
 static uint8_t write_buf[VMU_BLOCK_SIZE] __attribute__((aligned(4)));
 static uint16_t write_block  = 0xFFFF;
@@ -209,9 +210,11 @@ void vmu_init(uint8_t port_addr) {
 // Called after controller enumerates with DC — selects a persistence backend
 // (USB flash > SD > QSPI > RAM) and loads any saved image. Deferred from
 // vmu_init() to avoid blocking Maple Bus enumeration.
-void vmu_sd_load(void) {
+bool vmu_sd_load(void) {
+    // vmu_storage_init() probes QSPI first (primary), then SD as backup.
+    // Returns true if any persistent backend is available (QSPI always is).
     vmu_storage_init();
-    printf("[VMU] Storage load complete\n");
+    return vmu_storage_backend() != VMU_BACKEND_NONE;
 }
 
 void vmu_set_slot(uint8_t slot)  { (void)slot; }
@@ -226,6 +229,8 @@ const void* __not_in_flash_func(vmu_get_block_read_packet)(uint32_t *sz)      { 
 const void* __not_in_flash_func(vmu_get_ack_packet)(uint32_t *sz)             { *sz=sizeof(vmu_ack_pkt)/4;       return &vmu_ack_pkt; }
 
 const void* __not_in_flash_func(vmu_handle_block_read)(const uint32_t *pkt, uint32_t *sz) {
+    // Signal Core 0 to show VMU activity LED
+    vmu_activity_flag = true;
     uint16_t block = (uint16_t)((pkt[1] >> 24) & 0xFF);
     if (block >= VMU_TOTAL_BLOCKS) block = 0;
     VmuBlockReadPkt *p = &vmu_block_read_pkt;
@@ -260,9 +265,11 @@ void __not_in_flash_func(vmu_handle_write_complete)(void) {
     vmu_status = VMU_STATUS_OK;
     // Signal Core 0 to flush to SD — use volatile flag, safe from RAM context
     vmu_dirty_flag = true;
+    // Signal Core 0 to show VMU activity LED
+    vmu_activity_flag = true;
 }
 
 void vmu_task(void) {
-    // Flush dirty VMU RAM to the active backend when its writeback timer expires
+    // Flush dirty VMU RAM to active backend (QSPI + SD backup if available)
     vmu_storage_task();
 }

--- a/src/native/device/dreamcast/vmu.h
+++ b/src/native/device/dreamcast/vmu.h
@@ -46,7 +46,10 @@ typedef enum {
 
 // Initialize VMU — call from dreamcast_init()
 void vmu_init(uint8_t port_addr);
-void vmu_sd_load(void);  // Call after Maple Bus enumeration to load SD data
+bool vmu_sd_load(void);  // Call after Maple Bus enumeration; returns true if storage backend available
+
+// Volatile activity flag — set by Core 1 on any VMU read/write, cleared by Core 0
+extern volatile bool vmu_activity_flag;
 
 // Build pre-built response packets — call from dreamcast_init()
 void vmu_build_packets(uint8_t port_addr);

--- a/src/native/device/dreamcast/vmu_sd.c
+++ b/src/native/device/dreamcast/vmu_sd.c
@@ -10,6 +10,7 @@
 // the only consequence of a torn read is a slightly early or late flush.
 
 #include "vmu_sd.h"
+#include "ff.h"
 #include "vmu.h"
 #include "core/services/sd/sd.h"
 #include "platform/platform_sd.h"
@@ -53,8 +54,31 @@ bool vmu_sd_init(void)
     printf("[vmu-sd] SD mounted (%llu MB free)\n",
            (unsigned long long)(sd_free_bytes() / (1024ULL * 1024ULL)));
 
-    // Try to load existing VMU image.
-    int got = sd_read_file(VMU_SD_FILENAME, vmu_ram, VMU_IMAGE_SIZE);
+    // Try to load existing VMU image using chunked reads.
+    // Some SD cards fail on a single 128KB f_read(); 512-byte chunks
+    // match the SD sector size and are universally reliable.
+    int got = 0;
+    {
+        FIL f;
+        if (f_open(&f, VMU_SD_FILENAME, FA_READ) == FR_OK) {
+            uint8_t* dst = (uint8_t*)vmu_ram;
+            size_t remaining = VMU_IMAGE_SIZE;
+            size_t offset = 0;
+            bool ok = true;
+            while (remaining > 0 && ok) {
+                UINT chunk = (UINT)(remaining > 512 ? 512 : remaining);
+                UINT rd = 0;
+                if (f_read(&f, dst + offset, chunk, &rd) != FR_OK || rd == 0) {
+                    ok = false;
+                } else {
+                    offset += rd;
+                    remaining -= rd;
+                }
+            }
+            f_close(&f);
+            if (ok) got = (int)VMU_IMAGE_SIZE;
+        }
+    }
     if (got == (int)VMU_IMAGE_SIZE) {
         printf("[vmu-sd] Loaded %s\n", VMU_SD_FILENAME);
     } else {
@@ -69,6 +93,40 @@ bool vmu_sd_init(void)
     }
 
     sd_available = true;
+    return true;
+#endif
+}
+
+// Mount SD card without loading VMU file — used when QSPI is primary backend.
+// QSPI image stays intact; first dirty writeback will sync QSPI -> SD.
+bool vmu_sd_mount(void)
+{
+#ifndef CONFIG_SD
+    return false;
+#else
+    static const platform_sd_config_t sd_cfg = {
+        .spi_inst    = SD_SPI_INST,
+        .sck_pin     = SD_SCK_PIN,
+        .mosi_pin    = SD_MOSI_PIN,
+        .miso_pin    = SD_MISO_PIN,
+        .cs_pin      = SD_CS_PIN,
+        .cd_pin      = PLATFORM_SD_NO_CD,
+        .init_freq_hz = 200000,
+        .run_freq_hz  = 12500000,
+    };
+
+    platform_sd_t dev = platform_sd_init(&sd_cfg);
+    if (!dev || !sd_init(dev)) {
+        printf("[vmu-sd] SD not available for backup\n");
+        return false;
+    }
+
+    printf("[vmu-sd] SD mounted for backup (%llu MB free)\n",
+           (unsigned long long)(sd_free_bytes() / (1024ULL * 1024ULL)));
+
+    // Mark dirty so first vmu_sd_task() call syncs QSPI image to SD
+    sd_available = true;
+    vmu_dirty_flag = true;
     return true;
 #endif
 }

--- a/src/native/device/dreamcast/vmu_sd.h
+++ b/src/native/device/dreamcast/vmu_sd.h
@@ -16,6 +16,7 @@
 // Creates the file from the pre-formatted image if not found.
 // Call once from Core 0 at startup. Returns true on success.
 bool vmu_sd_init(void);
+bool vmu_sd_mount(void);  // Mount SD without loading VMU file (QSPI-primary builds)
 
 // Periodic flush task — call from Core 0 main loop (via vmu_task()).
 void vmu_sd_task(void);

--- a/src/native/device/dreamcast/vmu_storage.c
+++ b/src/native/device/dreamcast/vmu_storage.c
@@ -7,6 +7,7 @@
 #include "vmu_storage.h"
 #include "vmu.h"
 #include "vmu_sd.h"
+#include "dreamcast_device.h"
 #include "pico/stdlib.h"
 #include <string.h>
 #include <stdio.h>
@@ -21,7 +22,8 @@
 extern uint8_t vmu_ram[];
 extern volatile bool vmu_dirty_flag;
 
-static vmu_backend_t active = VMU_BACKEND_NONE;
+static vmu_backend_t active = VMU_BACKEND_NONE;   // primary backend
+static bool sd_backup_active = false;              // SD backup available alongside QSPI
 
 // ===========================================================================
 // QSPI backend
@@ -60,6 +62,26 @@ static void qspi_flush(void) {
     const uint8_t* xip = qspi_xip();
     for (uint32_t off = 0; off < VMU_IMAGE_SIZE; off += FLASH_SECTOR_SIZE) {
         if (memcmp(vmu_ram + off, xip + off, FLASH_SECTOR_SIZE) == 0) continue;
+#ifdef CONFIG_NO_FLASH_LOCKOUT
+        // Pause Maple TX, wait for current packet to finish, erase+program,
+        // then resume. The DC tolerates one missed 16.7ms frame gracefully.
+        {
+            // vmu_dirty_flag is still set during flush — Core 0 LED blink handles this
+            // Pause Core 1 TX and wait for any in-flight packet to complete
+            dreamcast_set_maple_pause(true);
+            uint32_t before = dreamcast_rx_count();
+            uint32_t timeout = time_us_32() + 20000;  // 20ms max wait
+            while (dreamcast_rx_count() == before && time_us_32() < timeout) {
+                tight_loop_contents();
+            }
+            // Now erase+program with IRQ disabled
+            uint32_t ints = save_and_disable_interrupts();
+            flash_range_erase(VMU_QSPI_OFFSET + off, FLASH_SECTOR_SIZE);
+            flash_range_program(VMU_QSPI_OFFSET + off, vmu_ram + off, FLASH_SECTOR_SIZE);
+            restore_interrupts(ints);
+            dreamcast_set_maple_pause(false);
+        }
+#else
         qspi_sector_t s = { VMU_QSPI_OFFSET + off, vmu_ram + off };
         int r = flash_safe_execute(qspi_sector_worker, &s, UINT32_MAX);
         if (r != PICO_OK) {
@@ -69,6 +91,7 @@ static void qspi_flush(void) {
             flash_range_program(VMU_QSPI_OFFSET + off, vmu_ram + off, FLASH_SECTOR_SIZE);
             restore_interrupts(ints);
         }
+#endif
     }
 }
 
@@ -109,22 +132,37 @@ static void qspi_task(void) {
 // ===========================================================================
 
 void vmu_storage_init(void) {
-    // Priority: USB flash > SD card > QSPI > RAM-only.
+    // Priority: QSPI (primary, always reliable) > SD (backup) > RAM-only.
+    // SD is never the sole primary backend — it can block Core 0 during init
+    // long enough to disrupt Maple Bus timing and drop the DC controller.
+    // With QSPI as primary, VMU is always available immediately on boot.
+    // SD is initialized as an async backup when QSPI is active.
 #ifdef CONFIG_VMU_USB
-    // USB MSC backend (flash drive on a hub sharing the host port) — TODO:
-    // needs hub hardware to validate; falls through for now.
-#endif
-#ifdef CONFIG_SD
-    if (vmu_sd_init()) { active = VMU_BACKEND_SD; }
-    else
+    // USB MSC backend — TODO: needs hub hardware to validate.
 #endif
 #ifdef CONFIG_VMU_QSPI
-    if (qspi_init()) { active = VMU_BACKEND_QSPI; }
+    if (qspi_init()) {
+        active = VMU_BACKEND_QSPI;
+        // Mount SD as backup without loading from it — QSPI is the source
+        // of truth. vmu_sd_mount() marks dirty so the first vmu_sd_task()
+        // call will sync the QSPI image to SD.
+#ifdef CONFIG_SD
+        if (vmu_sd_mount()) {
+            sd_backup_active = true;
+            printf("[vmu-storage] SD backup active\n");
+        }
+#endif
+    } else
+#endif
+#ifdef CONFIG_SD
+    // Fallback: SD only (no QSPI) — legacy behaviour for non-QSPI builds
+    if (vmu_sd_init()) { active = VMU_BACKEND_SD; }
     else
 #endif
     { active = VMU_BACKEND_NONE; }
 
-    printf("[vmu-storage] Backend: %s\n", vmu_storage_backend_name());
+    printf("[vmu-storage] Backend: %s%s\n", vmu_storage_backend_name(),
+           sd_backup_active ? " + SD backup" : "");
 }
 
 void vmu_storage_task(void) {
@@ -133,7 +171,13 @@ void vmu_storage_task(void) {
         case VMU_BACKEND_SD:   vmu_sd_task(); break;
 #endif
 #ifdef CONFIG_VMU_QSPI
-        case VMU_BACKEND_QSPI: qspi_task(); break;
+        case VMU_BACKEND_QSPI:
+            qspi_task();
+            // Also flush to SD backup if available
+#ifdef CONFIG_SD
+            if (sd_backup_active) vmu_sd_task();
+#endif
+            break;
 #endif
         default: break;
     }


### PR DESCRIPTION
Two categories of fixes: controller enumeration reliability and VMU storage architecture.

**Controller enumeration fix:**

Removes a DMA race condition in Core 1's TX path. When the DC sent a device info request, Core 1 would check dma_channel_is_busy() before sending the response and if DMA was busy finishing a previous transmission, the response was silently dropped and NextPacketSend cleared. SendPacket() already handles DMA completion internally via a wait loop, so the outer check was redundant and harmful. Removing it eliminates the intermittent "lottery" enumeration behavior.
VMU storage architecture:

QSPI flash is now primary VMU backend on joypad_dc_rp2040zero. VMU is always available immediately on boot, no SD card required.
SD card is async backup and mounts without loading (vmu_sd_mount()), syncs QSPI image to DC_1.VMU on first dirty writeback. Eliminates the previous issue where stale SD images could overwrite good QSPI data on boot.
CONFIG_NO_FLASH_LOCKOUT added to joypad_dc_rp2040zero so Core 1 is never paused by flash_safe_execute during SD init or QSPI writes.
QSPI flush uses maple_tx_pause + rx_count idle detection to safely erase and program flash between Maple Bus packets without dropping the controller.
Chunked 512-byte SD reads replace single 128KB f_read() call for reliability across different SD cards.

**LED feedback:**

Solid blue briefly on VMU block read
Blinking blue on VMU write, stays until QSPI + SD flush completes
Returns to amber when fully persisted
All LED updates on Core 0 via vmu_activity_flag; Core 1 sets flag only

Tested on: RP2040 Zero with SD card with wired and wireless USB controllers.