### PR TITLE
Global analog-stick deadzone (single user-facing knob)

### DIFF
--- a/esp/main/flash_esp32.c
+++ b/esp/main/flash_esp32.c
@@ -291,6 +291,19 @@ void flash_set_shoulder_swap(uint8_t on)
     flash_save(&runtime_settings);
 }
 
+// Global analog-stick deadzone persistence — referenced by core/router and
+// CDC commands compiled into the ESP build too. NVS-backed, mirroring the
+// RP2040 flash_set_deadzone contract.
+void flash_set_deadzone(uint8_t dz)
+{
+    if (dz > 127) dz = 127;
+    if (!runtime_settings_loaded) return;
+    if (runtime_settings.deadzone == dz && runtime_settings.router_saved) return;
+    runtime_settings.deadzone = dz;
+    runtime_settings.router_saved = 1;
+    flash_save(&runtime_settings);
+}
+
 // ----------------------------------------------------------------------------
 // RAM-only ephemeral state for joypad-live (PROFILE.SELECT, PROFILE.APPLY,
 // OVERLAY.SET) — mirrors src/core/services/storage/flash.c. No NVS writes,

--- a/nrf/src/flash_nrf.c
+++ b/nrf/src/flash_nrf.c
@@ -293,6 +293,19 @@ void flash_set_shoulder_swap(uint8_t on)
     flash_save(&runtime_settings);
 }
 
+// Global analog-stick deadzone persistence — referenced by core/router
+// compiled into the nRF build too. Mirrors the RP2040 flash_set_deadzone
+// contract.
+void flash_set_deadzone(uint8_t dz)
+{
+    if (dz > 127) dz = 127;
+    if (!runtime_settings_loaded) return;
+    if (runtime_settings.deadzone == dz && runtime_settings.router_saved) return;
+    runtime_settings.deadzone = dz;
+    runtime_settings.router_saved = 1;
+    flash_save(&runtime_settings);
+}
+
 // ----------------------------------------------------------------------------
 // RAM-only ephemeral state for joypad-live (PROFILE.SELECT, PROFILE.APPLY,
 // OVERLAY.SET) — mirrors src/core/services/storage/flash.c. No NVS writes,

--- a/src/core/router/router.c
+++ b/src/core/router/router.c
@@ -231,6 +231,7 @@ static router_config_t router_config;
 // Global d-pad mode (0=dpad, 1=left stick, 2=right stick)
 static uint8_t global_dpad_mode = 0;
 static bool global_shoulder_swap = false;  // swap L1<->L2, R1<->R2
+static uint8_t global_deadzone = 0;        // analog-stick deadzone radius (0-127, 0=off)
 
 // Global button combo hotkeys
 static struct {
@@ -290,6 +291,56 @@ static bool output_tap_exclusive[MAX_OUTPUTS] = {false};
 // ============================================================================
 // INITIALIZATION
 // ============================================================================
+
+// Integer square root (binary digit-by-digit). Used by the radial deadzone so
+// router.c stays free of <math.h>/sqrtf — it compiles on RP2040, ESP32, nRF
+// and WCH, and we don't want to depend on -lm across all of them.
+static uint32_t isqrt32(uint32_t v) {
+    uint32_t x = 0;
+    uint32_t bit = 1u << 30;
+    while (bit > v) bit >>= 2;
+    while (bit) {
+        if (v >= x + bit) {
+            v -= x + bit;
+            x = (x >> 1) + bit;
+        } else {
+            x >>= 1;
+        }
+        bit >>= 2;
+    }
+    return x;
+}
+
+// Radial, scaled deadzone applied to one stick (axes centered at 128).
+// Inside the deadzone radius the stick snaps to center; outside, the remaining
+// travel is rescaled so motion starts at zero just past the threshold and
+// still reaches full deflection (no jump at the edge). Diagonal corners are
+// preserved by clamping per-axis rather than the magnitude.
+static void apply_radial_deadzone(uint8_t* px, uint8_t* py, uint8_t dz) {
+    int x = (int)*px - 128;
+    int y = (int)*py - 128;
+    uint32_t m2 = (uint32_t)(x * x + y * y);
+    uint32_t dz2 = (uint32_t)dz * (uint32_t)dz;
+    if (m2 <= dz2) {           // inside deadzone → center
+        *px = 128;
+        *py = 128;
+        return;
+    }
+    uint32_t m = isqrt32(m2);  // current magnitude (>= dz here)
+    if (m == 0) return;
+    const int MAXR = 127;      // full-deflection radius
+    int denom = MAXR - (int)dz;
+    if (denom <= 0) return;    // dz == 127: leave raw value (degenerate)
+    int nm = ((int)(m - dz) * MAXR) / denom;  // rescaled magnitude
+    int nx = (x * nm) / (int)m;
+    int ny = (y * nm) / (int)m;
+    int ox = 128 + nx;
+    int oy = 128 + ny;
+    if (ox < 0) ox = 0; else if (ox > 255) ox = 255;
+    if (oy < 0) oy = 0; else if (oy > 255) oy = 255;
+    *px = (uint8_t)ox;
+    *py = (uint8_t)oy;
+}
 
 void router_init(const router_config_t* config) {
     if (!config) {
@@ -356,6 +407,22 @@ void router_init(const router_config_t* config) {
             printf(LOG_TAG "    - Instance merging\n");
         if (config->transform_flags & TRANSFORM_SPINNER)
             printf(LOG_TAG "    - Spinner accumulation\n");
+    }
+
+    // Restore the global analog-stick deadzone from flash. Done here (rather
+    // than per-app like dpad_mode) so every app picks it up with one code
+    // path. flash_load() is a read-only scan, safe before flash_init(); on a
+    // freshly-erased flash deadzone reads 0 (off), so behavior is unchanged
+    // until the user sets it via ROUTER.DEADZONE.SET.
+    {
+        flash_t flash_data;
+        if (flash_load(&flash_data) && flash_data.router_saved &&
+            flash_data.deadzone <= 127) {
+            global_deadzone = flash_data.deadzone;
+            if (global_deadzone) {
+                printf(LOG_TAG "  Analog deadzone: %u\n", global_deadzone);
+            }
+        }
     }
 }
 
@@ -1162,6 +1229,16 @@ void router_submit_input(const input_event_t* event) {
         event = &remapped;
     }
 
+    // Apply the global analog-stick deadzone (radial + scaled). Sticks only —
+    // analog triggers (L2/R2) are intentionally left untouched. Runs after the
+    // d-pad-to-stick remap so synthesized stick values are deadzoned too.
+    if (global_deadzone > 0) {
+        if (!did_remap) { remapped = *event; did_remap = true; }
+        apply_radial_deadzone(&remapped.analog[ANALOG_LX], &remapped.analog[ANALOG_LY], global_deadzone);
+        apply_radial_deadzone(&remapped.analog[ANALOG_RX], &remapped.analog[ANALOG_RY], global_deadzone);
+        event = &remapped;
+    }
+
     // Find first active route to determine output target
     output_target_t output = OUTPUT_TARGET_USB_DEVICE;
     for (uint8_t i = 0; i < MAX_ROUTES; i++) {
@@ -1495,6 +1572,12 @@ void router_set_dpad_mode(uint8_t mode) {
         static const char* names[] = {"D-PAD", "LEFT STICK", "RIGHT STICK"};
         printf(LOG_TAG "D-pad mode: %s\n", names[mode]);
     }
+}
+
+void router_set_deadzone(uint8_t dz) {
+    if (dz > 127) dz = 127;
+    global_deadzone = dz;
+    printf(LOG_TAG "Analog deadzone: %u\n", dz);
 }
 
 void router_set_combo(uint8_t index, uint32_t input_mask, uint32_t output_mask) {

--- a/src/core/router/router.h
+++ b/src/core/router/router.h
@@ -159,6 +159,11 @@ void router_set_dpad_mode(uint8_t mode);
 // Set global shoulder swap (L1<->L2, R1<->R2) applied to all inputs.
 void router_set_shoulder_swap(bool on);
 
+// Set the global analog-stick deadzone (0-127, radius around center; 0=off).
+// Radial + scaled, applied to both sticks above profiles. Runtime-only — use
+// flash_set_deadzone() to persist across reboot.
+void router_set_deadzone(uint8_t dz);
+
 // Set button combo hotkeys (up to ROUTER_COMBO_MAX)
 // input_mask: buttons that must all be held (0 = disabled)
 // output_mask: upper byte = action, lower 22 bits = output buttons

--- a/src/core/services/storage/flash.c
+++ b/src/core/services/storage/flash.c
@@ -560,6 +560,26 @@ void flash_set_shoulder_swap(uint8_t on)
     flash_save(&runtime_settings);
 }
 
+// Persist the global analog-stick deadzone (0-127). Idempotent.
+void flash_set_deadzone(uint8_t dz)
+{
+    if (dz > 127) dz = 127;
+    if (!runtime_settings_loaded) {
+        flash_t tmp;
+        if (!flash_load(&tmp)) memset(&tmp, 0, sizeof(tmp));
+        tmp.deadzone = dz;
+        tmp.router_saved = 1;
+        flash_save(&tmp);
+        return;
+    }
+    if (runtime_settings.deadzone == dz && runtime_settings.router_saved) {
+        return;
+    }
+    runtime_settings.deadzone = dz;
+    runtime_settings.router_saved = 1;
+    flash_save(&runtime_settings);
+}
+
 // Set active custom profile index (saves to flash with debouncing).
 // Persistent — clears any ephemeral override (APPLY + SELECT) so the
 // persisted value is what the device boots to.

--- a/src/core/services/storage/flash.h
+++ b/src/core/services/storage/flash.h
@@ -103,8 +103,13 @@ typedef struct {
     // reserved[] so the 256-byte layout is unchanged; old flashes read 0=off.
     uint8_t shoulder_swap;
 
-    // Reserved for future global settings (8 bytes)
-    uint8_t reserved[8];
+    // Global analog-stick deadzone (0-127, radius around center; 0=off).
+    // Applied at the router level to both sticks, above profiles. Carved from
+    // reserved[] so the 256-byte layout is unchanged; old flashes read 0=off.
+    uint8_t deadzone;
+
+    // Reserved for future global settings (7 bytes)
+    uint8_t reserved[7];
 
     // Custom profiles (4 x 56 = 224 bytes)
     custom_profile_t profiles[CUSTOM_PROFILE_MAX_COUNT];
@@ -255,5 +260,10 @@ void flash_set_dpad_mode(uint8_t mode);
 
 // Persist the shoulder-swap toggle (L1<->L2, R1<->R2). Marks router_saved=1.
 void flash_set_shoulder_swap(uint8_t on);
+
+// Persist the global analog-stick deadzone (0-127, radius around center;
+// 0=off). Marks router_saved=1 so the boot-time restore knows it was
+// explicitly chosen.
+void flash_set_deadzone(uint8_t dz);
 
 #endif // FLASH_H

--- a/src/pad/configs/abb.h
+++ b/src/pad/configs/abb.h
@@ -81,7 +81,7 @@ static const pad_device_config_t pad_config_abb = {
     .invert_ly = false,
     .invert_rx = false,
     .invert_ry = false,
-    .deadzone = 10,
+    .deadzone = 0,  // use the global router deadzone (ROUTER.DEADZONE.SET)
 
     // WS2812 RGB LEDs
     .led_pin = 4,

--- a/src/pad/configs/alpakka.h
+++ b/src/pad/configs/alpakka.h
@@ -99,7 +99,7 @@ static const pad_device_config_t pad_config_alpakka = {
     .invert_ly = false,
     .invert_rx = false,
     .invert_ry = false,
-    .deadzone = 10,
+    .deadzone = 0,  // use the global router deadzone (ROUTER.DEADZONE.SET)
 
     // No NeoPixel on standard Alpakka (uses OLED + LEDs on GPIO 2-5)
     .led_pin = PAD_PIN_DISABLED,

--- a/src/pad/configs/fisherprice.h
+++ b/src/pad/configs/fisherprice.h
@@ -80,7 +80,7 @@ static const pad_device_config_t pad_config_fisherprice_v1 = {
     .invert_ly = false,
     .invert_rx = false,
     .invert_ry = false,
-    .deadzone = 10,
+    .deadzone = 0,  // use the global router deadzone (ROUTER.DEADZONE.SET)
 
     // NeoPixel on GPIO 17
     .led_pin = 17,
@@ -168,7 +168,7 @@ static const pad_device_config_t pad_config_fisherprice_v2 = {
     .invert_ly = true,
     .invert_rx = false,
     .invert_ry = false,
-    .deadzone = 10,
+    .deadzone = 0,  // use the global router deadzone (ROUTER.DEADZONE.SET)
 
     // NeoPixel on GPIO 17
     .led_pin = 17,

--- a/src/pad/configs/macropad.h
+++ b/src/pad/configs/macropad.h
@@ -96,7 +96,7 @@ static const pad_device_config_t pad_config_macropad = {
     .invert_ly = false,
     .invert_rx = false,
     .invert_ry = false,
-    .deadzone = 10,
+    .deadzone = 0,  // use the global router deadzone (ROUTER.DEADZONE.SET)
 
     // NeoPixel on GPIO 19 (12 LEDs, one per key)
     .led_pin = 19,

--- a/src/pad/pad_input.h
+++ b/src/pad/pad_input.h
@@ -261,7 +261,7 @@ extern const InputInterface pad_input_interface;
     .invert_ly = false, \
     .invert_rx = false, \
     .invert_ry = false, \
-    .deadzone = 10, \
+    .deadzone = 0, /* prefer the global router deadzone (ROUTER.DEADZONE.SET) as the single user knob */ \
     .led_pin = 0, /* 0 = use board default, >0 = override, <0 = explicit disable */ \
     .led_count = 0, \
     .speaker_pin = PAD_PIN_DISABLED, \

--- a/src/usb/usbd/cdc/cdc_commands.c
+++ b/src/usb/usbd/cdc/cdc_commands.c
@@ -1342,21 +1342,22 @@ static void cmd_router_get(const char* json)
 
     flash_t flash_data;
 #if REQUIRE_BT_INPUT
-    uint8_t rm = ROUTING_MODE, mm = MERGE_MODE, dm = 0, bti = 1;
+    uint8_t rm = ROUTING_MODE, mm = MERGE_MODE, dm = 0, bti = 1, dz = 0;
 #else
-    uint8_t rm = ROUTING_MODE, mm = MERGE_MODE, dm = 0, bti = 0;
+    uint8_t rm = ROUTING_MODE, mm = MERGE_MODE, dm = 0, bti = 0, dz = 0;
 #endif
     if (flash_load(&flash_data) && flash_data.router_saved) {
         if (flash_data.routing_mode <= 2) rm = flash_data.routing_mode;
         if (flash_data.merge_mode <= 2) mm = flash_data.merge_mode;
         if (flash_data.dpad_mode <= 2) dm = flash_data.dpad_mode;
+        if (flash_data.deadzone <= 127) dz = flash_data.deadzone;
         bti = flash_data.bt_input_enabled;
     }
     snprintf(response_buf, sizeof(response_buf),
              "{\"ok\":true,\"routing_mode\":%d,\"merge_mode\":%d,\"dpad_mode\":%d,"
-             "\"bt_input\":%s,"
+             "\"deadzone\":%d,\"bt_input\":%s,"
              "\"default_routing_mode\":%d,\"default_merge_mode\":%d}",
-             rm, mm, dm, bti ? "true" : "false",
+             rm, mm, dm, dz, bti ? "true" : "false",
              (int)ROUTING_MODE, (int)MERGE_MODE);
     send_json(response_buf);
 }
@@ -1370,6 +1371,18 @@ static void cmd_router_dpad_set(const char* json)
     }
     router_set_dpad_mode((uint8_t)mode);
     flash_set_dpad_mode((uint8_t)mode);   // persist (no reboot needed)
+    send_ok();
+}
+
+static void cmd_router_deadzone_set(const char* json)
+{
+    int dz;
+    if (!json_get_int(json, "deadzone", &dz) || dz < 0 || dz > 127) {
+        send_error("Invalid deadzone (0-127)");
+        return;
+    }
+    router_set_deadzone((uint8_t)dz);
+    flash_set_deadzone((uint8_t)dz);   // persist (no reboot needed)
     send_ok();
 }
 
@@ -2766,6 +2779,7 @@ static const cmd_entry_t commands[] = {
     {"ROUTER.GET", cmd_router_get},
     {"ROUTER.SET", cmd_router_set},
     {"ROUTER.DPAD.SET", cmd_router_dpad_set},
+    {"ROUTER.DEADZONE.SET", cmd_router_deadzone_set},
     {"CAPS.GET", cmd_caps_get},
     {"OUTPUT.NATIVE.GET", cmd_output_native_get},
     {"OUTPUT.NATIVE.SET", cmd_output_native_set},

--- a/wch/src/flash_wch.c
+++ b/wch/src/flash_wch.c
@@ -192,6 +192,14 @@ void flash_set_shoulder_swap(uint8_t on)
     runtime_settings.router_saved = 1;
 }
 
+void flash_set_deadzone(uint8_t dz)
+{
+    if (dz > 127) dz = 127;
+    if (!runtime_settings_loaded) return;
+    runtime_settings.deadzone = dz;
+    runtime_settings.router_saved = 1;
+}
+
 // ----------------------------------------------------------------------------
 // RAM-only ephemeral state for joypad-live (PROFILE.SELECT/APPLY, OVERLAY.SET)
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds a single **global analog-stick deadzone** — one router-level value applied to both sticks, above profiles, set over CDC via `ROUTER.DEADZONE.SET` (0–127, **default 0 = off**, so nothing changes until set).

Radial + scaled: removes center jitter without losing full deflection or diagonal corners. Triggers (L2/R2) untouched. Integer-only math (no `sqrtf`/`-lm`) since `router.c` compiles on all four platforms.

## Why

The UX goal is "I just want to fix the controller I'm using for my setup, and adjust if I swap controllers later." A single runtime knob beats per-make/model defaults — those can't predict an individual unit's stick wear.

## How

- **flash**: `uint8_t deadzone` carved from `reserved[]` (256-byte layout unchanged, no schema bump; old flashes read 0=off) + `flash_set_deadzone()` stubbed on RP2040/ESP32/nRF/WCH (per the all-platforms-or-CI-fails rule).
- **router**: `global_deadzone`, `isqrt32` + `apply_radial_deadzone()`, `router_set_deadzone()`, restored from flash **centrally in `router_init()`** so all ~42 apps pick it up with one code path (vs `dpad_mode`'s per-app pattern).
- **cdc**: `deadzone` added to `ROUTER.GET`; `ROUTER.DEADZONE.SET` registered.

## Consolidation

Folds the per-pad deadzone into this single knob:
- `pad_input` default `10 → 0` and the 5 identical `.deadzone = 10` config copies → `0`, so they no longer stack on the global value.
- **Left alone:** native-host GC/Wii (±3, calibration tolerance tied to per-session auto-ranging) and PCE-Mini (64, analog→digital threshold). Different mechanism, not user-preference deadzone.

⚠️ Behavior note: freshly-flashed DIY pad builds now ship with no deadzone until the global one is set — consistent with how USB controllers already behaved.

## Usage

```json
{"cmd":"ROUTER.DEADZONE.SET","deadzone":20}
```
Applies immediately and persists; `ROUTER.GET` now returns the current `deadzone`.

## Builds verified

RP2040 (`usb2gc`, `controller_btusb_abb`, `bt2usb_pico_w`), ESP32-S3 (`bt2usb_xiao_esp32s3`), nRF52840 (`bt2usb_seeed_xiao_nrf52840`).

## Follow-ups (not in this PR)

- Surface the deadzone in joypad-web's UI.
- Generalize GC's per-session stick auto-ranging to USB sticks (the real per-unit-wear fix).