### PR TITLE
USB host: cascaded/multi-hub support + 5-controller fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -474,6 +474,10 @@ message(STATUS "Board ${PICO_BOARD}: BUTTON_USER_GPIO=${BOARD_BUTTON_GPIO}")
 # --- PCEngine ---
 add_executable(joypad_pce)
 target_compile_definitions(joypad_pce PRIVATE CONFIG_PCE=1)
+# PCEngine multitap = 5 players. Allow chaining a second hub (e.g. PCE Mini
+# 5-port hub, itself 2 cascaded chips, + another hub). CFG_TUH_HUB=4 ->
+# CFG_TUH_DEVICE_MAX=17 -> max dev_addr 21, so MAX_DEVICES must be >= 22.
+target_compile_definitions(joypad_pce PRIVATE CFG_TUH_HUB=4 MAX_DEVICES=22)
 if (PICO_BOARD STREQUAL "pico")
     target_compile_definitions(joypad_pce PRIVATE RPI_PICO_BUILD=1)
 endif()

--- a/src/core/buttons.h
+++ b/src/core/buttons.h
@@ -29,7 +29,13 @@
  *  Extended: A2=Touchpad/Capture  A3=Mute  L4/R4=Paddles
  */
 
+// Sized to cover the highest USB dev_addr the host can assign
+// (CFG_TUH_DEVICE_MAX + CFG_TUH_HUB + 1). devices[] and every driver's
+// per-device array are indexed by dev_addr, so this must be >= max dev_addr.
+// Overridable per-app: usb2pce raises it to 22 alongside CFG_TUH_HUB=4.
+#ifndef MAX_DEVICES
 #define MAX_DEVICES 12
+#endif
 
 // W3C Gamepad API standard button order
 // Bit position = W3C button index (trivial conversion: 1 << index)

--- a/src/core/buttons.h
+++ b/src/core/buttons.h
@@ -29,7 +29,7 @@
  *  Extended: A2=Touchpad/Capture  A3=Mute  L4/R4=Paddles
  */
 
-#define MAX_DEVICES 6
+#define MAX_DEVICES 12
 
 // W3C Gamepad API standard button order
 // Bit position = W3C button index (trivial conversion: 1 << index)

--- a/src/tusb_config.h
+++ b/src/tusb_config.h
@@ -109,7 +109,11 @@
 #define CFG_TUH_MEM_ALIGN        __attribute__ ((aligned(4)))
 #endif
 
-#define CFG_TUH_HUB                 1
+// 2 hubs: many multi-port hubs (e.g. the PC Engine Mini 5-port hub) are two
+// cascaded hub chips internally, so a single such hub presents as 2 hub
+// devices. At 1, the second-tier chip never enumerates and every controller
+// behind it is dead — which is why hubs regressed vs the USBRetro era.
+#define CFG_TUH_HUB                 2
 #define CFG_TUH_CDC                 0
 #define CFG_TUH_HID                 8   // Max 8 HID interfaces total (2 per device typical)
 // Mass storage host: opt-in per target via CONFIG_USB_MSC. Default-off so

--- a/src/tusb_config.h
+++ b/src/tusb_config.h
@@ -124,7 +124,7 @@
 #define CFG_TUH_MSC                 0
 #endif
 #define CFG_TUH_VENDOR              0
-#define CFG_TUH_XINPUT              4   // Max 4 XInput interfaces (Xbox wireless adapter has 4 ports)
+#define CFG_TUH_XINPUT              8   // Max 8 XInput interfaces (5 pads through a hub + Xbox wireless adapter ports)
 
 // Bluetooth dongle support - only enabled when ENABLE_BTSTACK is defined by CMake
 // CYW43 targets use built-in BT via pico_btstack, not USB dongle class

--- a/src/tusb_config.h
+++ b/src/tusb_config.h
@@ -113,7 +113,12 @@
 // cascaded hub chips internally, so a single such hub presents as 2 hub
 // devices. At 1, the second-tier chip never enumerates and every controller
 // behind it is dead — which is why hubs regressed vs the USBRetro era.
+// Overridable per-app (usb2pce sets 4 to allow chaining a second hub). When
+// raised, MAX_DEVICES (core/buttons.h) must grow to cover dev_addr up to
+// CFG_TUH_DEVICE_MAX + CFG_TUH_HUB.
+#ifndef CFG_TUH_HUB
 #define CFG_TUH_HUB                 2
+#endif
 #define CFG_TUH_CDC                 0
 #define CFG_TUH_HID                 8   // Max 8 HID interfaces total (2 per device typical)
 // Mass storage host: opt-in per target via CONFIG_USB_MSC. Default-off so

--- a/src/usb/usbh/hid/devices/generic/hid_gamepad.c
+++ b/src/usb/usbh/hid/devices/generic/hid_gamepad.c
@@ -311,7 +311,7 @@ static uint16_t read_axis_value(const uint8_t *report, const dinput_usage_t *loc
 void process_hid_gamepad(uint8_t dev_addr, uint8_t instance, uint8_t const* report, uint16_t len)
 {
   uint32_t buttons = 0;
-  static dinput_gamepad_t previous[5][5];
+  static dinput_gamepad_t previous[MAX_DEVICES][5];
   dinput_gamepad_t current = {0};
   current.value = 0;
 

--- a/src/usb/usbh/hid/devices/vendors/8bitdo/8bitdo_bta.c
+++ b/src/usb/usbh/hid/devices/vendors/8bitdo/8bitdo_bta.c
@@ -34,7 +34,7 @@ bool diff_report_bta(bitdo_bta_report_t const* rpt1, bitdo_bta_report_t const* r
 void process_8bitdo_bta(uint8_t dev_addr, uint8_t instance, uint8_t const* report, uint16_t len) {
   uint32_t buttons;
   // previous report used to compare for changes
-  static bitdo_bta_report_t prev_report[5] = { 0 };
+  static bitdo_bta_report_t prev_report[MAX_DEVICES] = { 0 };
 
   bitdo_bta_report_t input_report;
   memcpy(&input_report, report, sizeof(input_report));

--- a/src/usb/usbh/hid/devices/vendors/8bitdo/8bitdo_m30.c
+++ b/src/usb/usbh/hid/devices/vendors/8bitdo/8bitdo_m30.c
@@ -21,7 +21,7 @@ bool diff_report_m30(bitdo_m30_report_t const* rpt1, bitdo_m30_report_t const* r
 void process_8bitdo_m30(uint8_t dev_addr, uint8_t instance, uint8_t const* report, uint16_t len) {
   uint32_t buttons;
   // previous report used to compare for changes
-  static bitdo_m30_report_t prev_report[5] = { 0 };
+  static bitdo_m30_report_t prev_report[MAX_DEVICES] = { 0 };
 
   bitdo_m30_report_t input_report;
   memcpy(&input_report, report, sizeof(input_report));

--- a/src/usb/usbh/hid/devices/vendors/8bitdo/8bitdo_neo.c
+++ b/src/usb/usbh/hid/devices/vendors/8bitdo/8bitdo_neo.c
@@ -18,7 +18,7 @@ bool diff_report_neo(bitdo_neo_report_t const* rpt1, bitdo_neo_report_t const* r
 void process_8bitdo_neo(uint8_t dev_addr, uint8_t instance, uint8_t const* report, uint16_t len) {
   uint32_t buttons;
   // previous report used to compare for changes
-  static bitdo_neo_report_t prev_report[5] = { 0 };
+  static bitdo_neo_report_t prev_report[MAX_DEVICES] = { 0 };
 
   bitdo_neo_report_t input_report;
   memcpy(&input_report, report, sizeof(input_report));

--- a/src/usb/usbh/hid/devices/vendors/8bitdo/8bitdo_pce.c
+++ b/src/usb/usbh/hid/devices/vendors/8bitdo/8bitdo_pce.c
@@ -27,7 +27,7 @@ bool diff_report_pce(bitdo_pce_report_t const* rpt1, bitdo_pce_report_t const* r
 void process_8bitdo_pce(uint8_t dev_addr, uint8_t instance, uint8_t const* report, uint16_t len) {
   uint32_t buttons;
   // previous report used to compare for changes
-  static bitdo_pce_report_t prev_report[5] = { 0 };
+  static bitdo_pce_report_t prev_report[MAX_DEVICES] = { 0 };
 
   bitdo_pce_report_t pce_report;
   memcpy(&pce_report, report, sizeof(pce_report));

--- a/src/usb/usbh/hid/devices/vendors/dragonrise/dragonrise.c
+++ b/src/usb/usbh/hid/devices/vendors/dragonrise/dragonrise.c
@@ -28,7 +28,7 @@ bool dragonrise_diff_report(dragonrise_report_t const* rpt1, dragonrise_report_t
 void process_dragonrise(uint8_t dev_addr, uint8_t instance, uint8_t const* report, uint16_t len) {
   uint32_t buttons;
   // previous report used to compare for changes
-  static dragonrise_report_t prev_report[5][5];
+  static dragonrise_report_t prev_report[MAX_DEVICES][5];
 
   dragonrise_report_t update_report;
   memcpy(&update_report, report, sizeof(update_report));

--- a/src/usb/usbh/hid/devices/vendors/hori/hori_horipad.c
+++ b/src/usb/usbh/hid/devices/vendors/hori/hori_horipad.c
@@ -49,7 +49,7 @@ bool diff_report_horipad(hori_horipad_report_t const* rpt1, hori_horipad_report_
 void process_hori_horipad(uint8_t dev_addr, uint8_t instance, uint8_t const* report, uint16_t len) {
   uint32_t buttons;
   // previous report used to compare for changes
-  static hori_horipad_report_t prev_report[5] = { 0 };
+  static hori_horipad_report_t prev_report[MAX_DEVICES] = { 0 };
 
   hori_horipad_report_t input_report;
   memcpy(&input_report, report, sizeof(input_report));

--- a/src/usb/usbh/hid/devices/vendors/hori/hori_pokken.c
+++ b/src/usb/usbh/hid/devices/vendors/hori/hori_pokken.c
@@ -26,7 +26,7 @@ bool diff_report_pokken(hori_pokken_report_t const* rpt1, hori_pokken_report_t c
 void process_hori_pokken(uint8_t dev_addr, uint8_t instance, uint8_t const* report, uint16_t len) {
   uint32_t buttons;
   // previous report used to compare for changes
-  static hori_pokken_report_t prev_report[5][5];
+  static hori_pokken_report_t prev_report[MAX_DEVICES][5];
 
   hori_pokken_report_t update_report;
   memcpy(&update_report, report, sizeof(update_report));

--- a/src/usb/usbh/hid/devices/vendors/logitech/logitech_wingman.c
+++ b/src/usb/usbh/hid/devices/vendors/logitech/logitech_wingman.c
@@ -35,7 +35,7 @@ bool diff_report_logitech_wingman(logitech_wingman_report_t const* rpt1, logitec
 void process_logitech_wingman(uint8_t dev_addr, uint8_t instance, uint8_t const* report, uint16_t len) {
   uint32_t buttons;
   // previous report used to compare for changes
-  static logitech_wingman_report_t prev_report[5] = { 0 };
+  static logitech_wingman_report_t prev_report[MAX_DEVICES] = { 0 };
 
   logitech_wingman_report_t wingman_report;
   memcpy(&wingman_report, report, sizeof(wingman_report));

--- a/src/usb/usbh/hid/devices/vendors/misc/triple_adapter_v1.c
+++ b/src/usb/usbh/hid/devices/vendors/misc/triple_adapter_v1.c
@@ -43,7 +43,7 @@ bool diff_report_triple_adapter_v1(triple_adapter_v1_report_t const* rpt1, tripl
 void process_triple_adapter_v1(uint8_t dev_addr, uint8_t instance, uint8_t const* report, uint16_t len) {
   uint32_t buttons;
   // previous report used to compare for changes
-  static triple_adapter_v1_report_t prev_report[5][5];
+  static triple_adapter_v1_report_t prev_report[MAX_DEVICES][5];
 
   triple_adapter_v1_report_t update_report;
   memcpy(&update_report, report, sizeof(update_report));

--- a/src/usb/usbh/hid/devices/vendors/misc/triple_adapter_v2.c
+++ b/src/usb/usbh/hid/devices/vendors/misc/triple_adapter_v2.c
@@ -44,7 +44,7 @@ bool diff_report_triple_adapter_v2(triple_adapter_v2_report_t const* rpt1, tripl
 void process_triple_adapter_v2(uint8_t dev_addr, uint8_t instance, uint8_t const* report, uint16_t len) {
   uint32_t buttons;
   // previous report used to compare for changes
-  static triple_adapter_v2_report_t prev_report[5][5];
+  static triple_adapter_v2_report_t prev_report[MAX_DEVICES][5];
 
   triple_adapter_v2_report_t update_report;
   memcpy(&update_report, report, sizeof(update_report));

--- a/src/usb/usbh/hid/devices/vendors/nintendo/gamecube_adapter.c
+++ b/src/usb/usbh/hid/devices/vendors/nintendo/gamecube_adapter.c
@@ -30,7 +30,7 @@ bool diff_report_gamecube_adapter(gamecube_adapter_report_t const* rpt1, gamecub
 void input_gamecube_adapter(uint8_t dev_addr, uint8_t instance, uint8_t const* report, uint16_t len) {
   uint32_t buttons;
   // previous report used to compare for changes
-  static gamecube_adapter_report_t prev_report[5][4];
+  static gamecube_adapter_report_t prev_report[MAX_DEVICES][4];
 
   gamecube_adapter_report_t gamecube_report;
   memcpy(&gamecube_report, report, sizeof(gamecube_report));

--- a/src/usb/usbh/hid/devices/vendors/nintendo/switch_pro.c
+++ b/src/usb/usbh/hid/devices/vendors/nintendo/switch_pro.c
@@ -188,7 +188,7 @@ void input_report_switch_pro(uint8_t dev_addr, uint8_t instance, uint8_t const* 
 {
   uint32_t buttons;
   // previous report used to compare for changes
-  static switch_pro_report_t prev_report[5][5];
+  static switch_pro_report_t prev_report[MAX_DEVICES][5];
 
   switch_pro_report_t update_report;
   memcpy(&update_report, report, sizeof(update_report));

--- a/src/usb/usbh/hid/devices/vendors/raphnet/raphnet_pce.c
+++ b/src/usb/usbh/hid/devices/vendors/raphnet/raphnet_pce.c
@@ -38,7 +38,7 @@ typedef struct __attribute__((packed)) {
 } raphnet_pce_report_t;
 
 // Previous report for change detection
-static raphnet_pce_report_t prev_report[5];
+static raphnet_pce_report_t prev_report[MAX_DEVICES];
 
 // Check if device is Raphnet PCE adapter
 static bool is_raphnet_pce(uint16_t vid, uint16_t pid) {

--- a/src/usb/usbh/hid/devices/vendors/sega/sega_astrocity.c
+++ b/src/usb/usbh/hid/devices/vendors/sega/sega_astrocity.c
@@ -37,7 +37,7 @@ bool diff_report_sega_astrocity(sega_astrocity_report_t const* rpt1, sega_astroc
 void process_sega_astrocity(uint8_t dev_addr, uint8_t instance, uint8_t const* report, uint16_t len) {
   uint32_t buttons;
   // previous report used to compare for changes
-  static sega_astrocity_report_t prev_report[5] = { 0 };
+  static sega_astrocity_report_t prev_report[MAX_DEVICES] = { 0 };
 
   sega_astrocity_report_t astro_report;
   memcpy(&astro_report, report, sizeof(astro_report));

--- a/src/usb/usbh/hid/devices/vendors/sony/sony_ds3.c
+++ b/src/usb/usbh/hid/devices/vendors/sony/sony_ds3.c
@@ -95,7 +95,7 @@ bool diff_report_ds3(sony_ds3_report_t const* rpt1, sony_ds3_report_t const* rpt
 void input_sony_ds3(uint8_t dev_addr, uint8_t instance, uint8_t const* report, uint16_t len) {
   uint32_t buttons;
   // previous report used to compare for changes
-  static sony_ds3_report_t prev_report[5] = { 0 };
+  static sony_ds3_report_t prev_report[MAX_DEVICES] = { 0 };
 
   // Mark that we've received input (DS3 is active and ready)
   ds3_devices[dev_addr].instances[instance].input_received = true;

--- a/src/usb/usbh/hid/devices/vendors/sony/sony_ds4.c
+++ b/src/usb/usbh/hid/devices/vendors/sony/sony_ds4.c
@@ -141,7 +141,7 @@ void input_sony_ds4(uint8_t dev_addr, uint8_t instance, uint8_t const* report, u
 {
   uint32_t buttons;
   // previous report used to compare for changes
-  static sony_ds4_report_t prev_report[5] = { 0 };
+  static sony_ds4_report_t prev_report[MAX_DEVICES] = { 0 };
 
   uint8_t const report_id = report[0];
   report++;

--- a/src/usb/usbh/hid/devices/vendors/sony/sony_ds5.c
+++ b/src/usb/usbh/hid/devices/vendors/sony/sony_ds5.c
@@ -68,7 +68,7 @@ bool diff_report_ds5(sony_ds5_report_t const* rpt1, sony_ds5_report_t const* rpt
 void input_sony_ds5(uint8_t dev_addr, uint8_t instance, uint8_t const* report, uint16_t len) {
   uint32_t buttons;
   // previous report used to compare for changes
-  static sony_ds5_report_t prev_report[5] = { 0 };
+  static sony_ds5_report_t prev_report[MAX_DEVICES] = { 0 };
 
   uint8_t const report_id = report[0];
   report++;

--- a/src/usb/usbh/hid/devices/vendors/sony/sony_psc.c
+++ b/src/usb/usbh/hid/devices/vendors/sony/sony_psc.c
@@ -19,7 +19,7 @@ bool diff_report_psc(sony_psc_report_t const* rpt1, sony_psc_report_t const* rpt
 void process_sony_psc(uint8_t dev_addr, uint8_t instance, uint8_t const* report, uint16_t len) {
   uint32_t buttons;
   // previous report used to compare for changes
-  static sony_psc_report_t prev_report[5] = { 0 };
+  static sony_psc_report_t prev_report[MAX_DEVICES] = { 0 };
 
   sony_psc_report_t psc_report;
   memcpy(&psc_report, report, sizeof(psc_report));

--- a/src/usb/usbh/xinput/xinput.c
+++ b/src/usb/usbh/xinput/xinput.c
@@ -286,9 +286,12 @@ void xinput_task(void)
   if (now - last_feedback_ms < 20) return;
   last_feedback_ms = now;
 
-  // Track last-sent values per player to avoid redundant USB transfers
-  static uint8_t last_led[4] = {0};
-  static uint8_t last_rumble[4] = {0};
+  // Track last-sent values per player to avoid redundant USB transfers.
+  // MAX_PLAYERS (not 4) — the loop indexes [i] up to playersCount-1; the PCE
+  // multitap allows 5 players, so [4] overflowed and corrupted memory at the
+  // 5th controller.
+  static uint8_t last_led[MAX_PLAYERS] = {0};
+  static uint8_t last_rumble[MAX_PLAYERS] = {0};
 
   // Update rumble/LED state for each xinput device
   for (int i = 0; i < playersCount; ++i)


### PR DESCRIPTION
Fixes a chain of issues that prevented running multiple controllers through a USB hub (e.g. the PC Engine Mini 5-port hub) into a Joypad OS adapter — regressed since the USBRetro era. Four commits, each verified on hardware (usb2pce on KB2040 + a real PCEngine).

## 1. Cascaded hubs didn't enumerate at all — `CFG_TUH_HUB=2`
`c94be998` had reduced `CFG_TUH_HUB` 2→1. A 5-port hub is two cascaded hub chips internally, so at `HUB=1` the second tier never enumerates and **no** controller behind it works. Restored `CFG_TUH_HUB=2`. ✅ confirmed: PCE Mini hub works again.

## 2. >3 controllers behind a hub were rejected / corrupted — `MAX_DEVICES` + driver arrays
The host path assumed ≤5 total USB devices: `MAX_DEVICES=6` with `devices[]` indexed by `dev_addr`, plus ~17 driver `prev_report[5]` arrays indexed by `[dev_addr-1]`. A cascaded hub burns addresses 1–2, so controller #4 landed at `dev_addr 6` and was dropped (and naively bumping `MAX_DEVICES` would have overflowed the `[5]` arrays). Raised `MAX_DEVICES`→12 and resized every per-device driver array to `[MAX_DEVICES]`. Also `CFG_TUH_XINPUT` 4→8.

## 3. Chaining a second hub — `CFG_TUH_HUB=4` (usb2pce only)
Made `CFG_TUH_HUB`/`MAX_DEVICES` per-app overridable and set `HUB=4`/`MAX_DEVICES=22` for `joypad_pce` only (PCE multitap = 5 players; users chain hubs to reach them). Scoped to usb2pce so the larger device pool doesn't grow RAM on the tighter shared builds. ~173 KB BSS of 264 KB.

## 4. The 5th controller hung the whole firmware — `xinput_task` `[4]` overflow
With 5 controllers connected, pressing a button on the 5th froze Core 0 hard (no fault). Root-caused with a hardware-watchdog stage localizer to `xinput_task`: it cached per-player LED/rumble in `static uint8_t last_led[4]` / `last_rumble[4]` (XInput's old 4-controller max) but iterates **every USB player** (it filters on transport, not controller type — `Player_t` doesn't store type). At the 5th player, `last_led[4]`/`last_rumble[4]` wrote out of bounds → silent memory corruption → hang. **Affects any 5 USB controllers, not just XInput** (the `tuh_xinput_set_*` calls no-op on non-XInput devices, but the cache write happens regardless). Sized both arrays to `MAX_PLAYERS`. ✅ confirmed: 5 controllers solid.

## Follow-ups (not in this PR)
- pico-pio-usb hubs (feather host) have separate upstream limitations — out of scope.
- XInput-through-hub appears power-limited (Xbox pads on bus-powered hubs) — hardware, not firmware.
- Store controller type in `Player_t` so `xinput_task`/`hid_task` can skip non-matching slots instead of fanning out to all USB players.