### PR TITLE
fix: hid_mouse.c local_x/local_y type mismatch with int16_t delta_x/delta_y

### DIFF
--- a/src/usb/usbh/hid/devices/generic/hid_mouse.c
+++ b/src/usb/usbh/hid/devices/generic/hid_mouse.c
@@ -5,8 +5,8 @@
 #include "core/router/router.h"
 #include "core/input_event.h"
 
-static uint8_t local_x;
-static uint8_t local_y;
+static int8_t local_x;
+static int8_t local_y;
 
 // Button swap functionality
 // -------------------------


### PR DESCRIPTION
input_event.h was recently updated to change delta_x and delta_y from int8_t to int16_t to support high-resolution pointing devices like the MouthPad. However, hid_mouse.c was not updated to match and still declares local_x and local_y as uint8_t.
When a standard USB HID mouse reports negative movement (e.g. moving left or up), the HID report stores the value as an unsigned byte (e.g. 0xFF for -1). Previously this was assigned to int8_t delta_x which correctly interpreted 0xFF as -1. Now it's assigned to int16_t delta_x via uint8_t local_x, which zero-extends 0xFF to 255 — causing the cursor to fly in the positive direction on any negative mouse movement.

This affects all standard USB mice across all output modes.


**Fix:**

**Change local_x and local_y in hid_mouse.c from uint8_t to int8_t.**

```
// Before
static uint8_t local_x;
static uint8_t local_y;

// After
static int8_t local_x;
static int8_t local_y;
```