### PR TITLE
fix(ps4): build on RP2350 + stub PS4 auth on ESP/nRF

### DIFF
--- a/esp/main/CMakeLists.txt
+++ b/esp/main/CMakeLists.txt
@@ -24,6 +24,7 @@ endif()
 set(ESP32_COMMON_SRCS
     "main.c"
     "flash_esp32.c"
+    "ps4_auth_stubs.c"
     "ws2812_esp32.c"
     "button_esp32.c"
     "${SHARED_SRC}/platform/esp32/platform_esp32.c"

--- a/esp/main/ps4_auth_stubs.c
+++ b/esp/main/ps4_auth_stubs.c
@@ -1,0 +1,24 @@
+// PS4 auth flash + event-log stubs for ESP32-S3.
+//
+// The shared cdc_commands.c always registers the PS4AUTH.*/PS4LOG.* CDC handlers,
+// which reference ps4_auth_flash_* and ps4_event_log_*. Those implementations live
+// in the RP2040 build (they use pico-sdk flash APIs) and are not built here. PS4
+// controller emulation is RP2040-only anyway (ESP32-S3 is BLE→USB HID), so provide
+// no-op stubs: PS4AUTH.STATUS reports "not installed" and the config UI hides the
+// PS4 Auth page.
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include "core/services/storage/ps4_auth_flash.h"
+#include "core/services/storage/ps4_event_log.h"
+
+bool ps4_auth_flash_load(ps4_auth_data_t *out) { (void)out; return false; }
+void ps4_auth_flash_save(const ps4_auth_data_t *data) { (void)data; }
+void ps4_auth_flash_erase(void) {}
+bool ps4_auth_flash_is_valid(const ps4_auth_data_t *data) { (void)data; return false; }
+
+void ps4_event_log_init(void) {}
+void ps4_event_log_write(const char *msg) { (void)msg; }
+int ps4_event_log_dump(char *out, size_t maxlen) { (void)out; (void)maxlen; return 0; }
+void ps4_event_log_clear(void) {}
+uint8_t ps4_event_log_count(void) { return 0; }

--- a/nrf/CMakeLists.txt
+++ b/nrf/CMakeLists.txt
@@ -42,6 +42,7 @@ set(SRCS
     # --- nRF-specific ---
     "src/main.c"
     "src/flash_nrf.c"
+    "src/ps4_auth_stubs.c"
     "src/ws2812_nrf.c"
     "src/button_nrf.c"
     "src/platform_gpio_nrf.c"

--- a/nrf/src/ps4_auth_stubs.c
+++ b/nrf/src/ps4_auth_stubs.c
@@ -1,0 +1,24 @@
+// PS4 auth flash + event-log stubs for nRF52840.
+//
+// The shared cdc_commands.c always registers the PS4AUTH.*/PS4LOG.* CDC handlers,
+// which reference ps4_auth_flash_* and ps4_event_log_*. Those implementations live
+// in the RP2040 build (they use pico-sdk flash APIs) and are not built here. PS4
+// controller emulation is RP2040-only anyway (nRF52840 is BLE→USB HID), so provide
+// no-op stubs: PS4AUTH.STATUS reports "not installed" and the config UI hides the
+// PS4 Auth page.
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include "core/services/storage/ps4_auth_flash.h"
+#include "core/services/storage/ps4_event_log.h"
+
+bool ps4_auth_flash_load(ps4_auth_data_t *out) { (void)out; return false; }
+void ps4_auth_flash_save(const ps4_auth_data_t *data) { (void)data; }
+void ps4_auth_flash_erase(void) {}
+bool ps4_auth_flash_is_valid(const ps4_auth_data_t *data) { (void)data; return false; }
+
+void ps4_event_log_init(void) {}
+void ps4_event_log_write(const char *msg) { (void)msg; }
+int ps4_event_log_dump(char *out, size_t maxlen) { (void)out; (void)maxlen; return 0; }
+void ps4_event_log_clear(void) {}
+uint8_t ps4_event_log_count(void) { return 0; }

--- a/src/usb/usbd/modes/ps4_local_auth.c
+++ b/src/usb/usbd/modes/ps4_local_auth.c
@@ -30,7 +30,12 @@
 #include "hardware/clocks.h"
 #include "hardware/sync.h"
 #include "hardware/watchdog.h"
+#if !PICO_RP2350
+// RP2040-only: chip_reset boot-source register lives in the VREG_AND_CHIP_RESET
+// block, which does not exist on RP2350 (moved into POWMAN). Used only for reset
+// diagnostics below, so guard it out on RP2350 rather than porting the readout.
 #include "hardware/structs/vreg_and_chip_reset.h"
+#endif
 #include "hardware/structs/watchdog.h"
 #include <string.h>
 #include <stdio.h>
@@ -285,6 +290,7 @@ bool ps4_local_auth_init(void)
     {
         bool wdog = watchdog_caused_reboot();
         bool wdog_en = watchdog_enable_caused_reboot();
+#if !PICO_RP2350
         uint32_t chip_reset = vreg_and_chip_reset_hw->chip_reset;
         // RP2040 bits: [20]=HAD_PSM_RESTART, [16]=HAD_RUN, [8]=HAD_POR
         bool had_por  = (chip_reset >>  8) & 1;
@@ -296,6 +302,14 @@ bool ps4_local_auth_init(void)
         ps4_log(rst);
         printf("[ps4_auth] %s wdog_en=%d chip_reset=0x%08lx\n",
                rst, wdog_en, (unsigned long)chip_reset);
+#else
+        // RP2350: chip_reset boot-source bits live in POWMAN; skip the detailed
+        // readout and just log the watchdog cause.
+        char rst[48];
+        snprintf(rst, sizeof(rst), "RST wd=%d wd_en=%d", wdog, wdog_en);
+        ps4_log(rst);
+        printf("[ps4_auth] %s\n", rst);
+#endif
     }
 
     // Log crash location from previous boot.


### PR DESCRIPTION
Fixes the two remaining build regressions from #171 (verified via branch CI before merge).

**RP2350** — `ps4_local_auth.c` included the RP2040-only `hardware/structs/vreg_and_chip_reset.h`; guarded with `#if !PICO_RP2350`. Fixes usb2usb_rp2350usba, {usb2usb,bt2usb}_pico2_w, bt2usb_waveshare_rp2350b_plus_w.

**ESP32-S3 / nRF52840** — shared `cdc_commands.c` references `ps4_auth_flash_*`/`ps4_event_log_*` (RP2040-only impls). Added no-op stubs; PS4 auth is RP2040-only so these boards report not-installed and the config page hides.

https://claude.ai/code/session_013A5gw3mEPkxbL1GdGFC2J6