### PR TITLE
fix(esp): prevent --gc-sections from discarding bthid_registry drivers

### DIFF
--- a/esp/main/CMakeLists.txt
+++ b/esp/main/CMakeLists.txt
@@ -354,6 +354,8 @@ if(APP_NEEDS_BTSTACK)
             "${SHARED_SRC}/bt/bthid/devices/vendors/microsoft/xbox_bt.c"
             "${SHARED_SRC}/bt/bthid/devices/vendors/microsoft/xbox_ble.c"
             "${SHARED_SRC}/bt/bthid/devices/vendors/google/stadia_bt.c"
+            "${SHARED_SRC}/bt/bthid/devices/generic/sinput_ble.c"
+            "${SHARED_SRC}/bt/bthid/devices/vendors/augmental/mouthpad_ble.c"
 
             # BTstack host + transport
             "${SHARED_SRC}/bt/btstack/btstack_host.c"

--- a/src/apps/bt2usb/app.c
+++ b/src/apps/bt2usb/app.c
@@ -14,6 +14,7 @@
 #include "usb/usbd/usbd.h"
 #include "bt/transport/bt_transport.h"
 #include "bt/btstack/btstack_host.h"
+#include "bt/bthid/bthid_registry.h"
 #include "core/services/leds/leds.h"
 
 #include "tusb.h"
@@ -415,8 +416,13 @@ void app_init(void)
     // Must use bt_init() to set global transport pointer and register drivers
     printf("[app:bt2usb] Initializing Bluetooth...\n");
 #ifdef BTSTACK_USE_ESP32
+    // Call bthid_registry_init BEFORE bt_init so the weak stub inside
+    // bt_transport.c is bypassed — ESP-IDF's --gc-sections would otherwise
+    // discard the strong symbol from bthid_registry.c.
+    bthid_registry_init();
     bt_init(&bt_transport_esp32);
 #elif defined(BTSTACK_USE_NRF)
+    bthid_registry_init();
     bt_init(&bt_transport_nrf);
 #else
     bt_init(&bt_transport_cyw43);


### PR DESCRIPTION
## Problem

On ESP32-S3 bt2usb builds, `bthid_registry.c.obj` is silently discarded
by ESP-IDF's `--gc-sections` linker garbage collection. The built firmware
compiles without errors, but `bthid_registry_init()` runs as an empty
stub — none of the BLE HID device drivers (Stadia, Switch Pro, DS4, DS5,
SInput BLE, etc.) are registered, and `driver_count` stays at 0.

The weak symbol definition and the call site for `bthid_registry_init()`
reside in the same compilation unit (`bt_transport.c`):

```c
// bt_transport.c — both the weak stub AND the call are here
__attribute__((weak)) void bthid_registry_init(void) {}

void bt_init(const bt_transport_t* transport) {
    ...
    bthid_registry_init();   // linker sees this resolved within the same .obj
    ...
}
```

With `--gc-sections`, the linker resolves the call to the weak stub
inside `bt_transport.c.obj` and never pulls in `bthid_registry.c.obj`,
which contains the strong definition that registers all drivers.

## Fix
Move `bthid_registry_init()` into `apps/bt2usb/app.c`, placing it
**before** `bt_init()`. This ensures:

1. The strong symbol is resolved from a separate object file, bypassing
   the `--gc-sections` issue entirely.
2. Drivers are registered **before** BTstack starts — no state-wiping risk.
3. The weak stub call inside `bt_init()` becomes a harmless no-op.

Additionally, add `sinput_ble.c` and `mouthpad_ble.c` to the ESP32
central-mode CMakeLists — these are referenced by `bthid_registry.c`
but were missing from the ESP32 build, causing link errors once the
strong symbol is resolved.

## Testing
- Built and verified on XIAO ESP32-S3 with a Google Stadia controller
- `[BTHID] Using driver: Google Stadia BT` — confirms driver registry works
- Full HID report pipeline: buttons, analog sticks, triggers verified