### PR TITLE
nrf: port uart_host to Zephyr (usb2usb)

### DIFF
--- a/nrf/CMakeLists.txt
+++ b/nrf/CMakeLists.txt
@@ -136,6 +136,9 @@ if(APP_TYPE STREQUAL "usb2usb")
         # --- MAX3421E host (nRF Zephyr port) ---
         "src/max3421_host_nrf.c"
 
+        # --- UART host (nRF Zephyr port of native/host/uart/uart_host.c) ---
+        "src/uart_host_nrf.c"
+
         # --- USB Host layer ---
         "${SHARED_SRC}/usb/usbh/usbh.c"
         "${SHARED_SRC}/usb/usbh/hid/hid.c"
@@ -189,6 +192,7 @@ if(APP_TYPE STREQUAL "usb2usb")
         "${SHARED_SRC}/apps/usb2usb"
         "${SHARED_SRC}/usb/usbh"
         "${SHARED_SRC}/lib/tusb_xinput"
+        "${SHARED_SRC}/native/host/uart"
     )
 
     target_compile_definitions(app PRIVATE
@@ -200,6 +204,14 @@ if(APP_TYPE STREQUAL "usb2usb")
         DISABLE_DISPLAY_SPI=1
         OLED_I2C_DISPLAY=1
         CFG_TUSB_CONFIG_FILE="tusb_config_nrf.h"
+        # MCP-driven synthetic input over the console UART (uart0) -- same
+        # UART that carries stdio logs, mirroring the RP2040 build where
+        # joypad-mcp shares one UART for both.
+        CONFIG_UART_HOST=1
+        UART_HOST_PERIPHERAL=uart0
+        CONFIG_UART_HOST_TX_PIN=0
+        CONFIG_UART_HOST_RX_PIN=0
+        CONFIG_UART_HOST_BAUD=115200
     )
 
 elseif(APP_TYPE STREQUAL "btusb2usb")

--- a/nrf/Makefile
+++ b/nrf/Makefile
@@ -1,6 +1,6 @@
 # Makefile for Joypad on nRF52840 boards (nRF Connect SDK / Zephyr)
 #
-# Supported boards: xiao_ble, adafruit_feather_nrf52840
+# Supported boards: xiao_ble, adafruit_feather_nrf52840, nrf52840dk
 # Supported apps:   bt2usb (default), usb2usb (with MAX3421E FeatherWing),
 #                   btusb2usb (MAX3421E + Bluetooth combined),
 #                   controller_btusb (sensor input + BLE peripheral + USB)
@@ -11,6 +11,7 @@
 #   make build BOARD=adafruit_feather_nrf52840  # Build for Feather
 #   make build APP_TYPE=usb2usb BOARD=adafruit_feather_nrf52840  # usb2usb
 #   make build APP_TYPE=btusb2usb BOARD=adafruit_feather_nrf52840  # btusb2usb
+#   make build APP_TYPE=usb2usb BOARD=nrf52840dk  # nRF52840-DK, flash via J-Link
 #   make flash-uf2         # Flash via UF2 bootloader drive
 #   make clean             # Remove build directory
 
@@ -21,10 +22,16 @@ APP_TYPE ?= bt2usb
 
 # Map JoypadOS board aliases -> actual Zephyr board. Overlay/conf are keyed off
 # the alias (BOARD), but west builds against ZEPHYR_BOARD. The April Brother
-# dongle is the upstream nrf52840dongle_nrf52840 board + a custom overlay.
+# dongle is the upstream nrf52840dongle_nrf52840 board + a custom overlay. The
+# nRF52840-DK is the upstream nrf52840dk/nrf52840 hardware-model-v2 target —
+# it has an onboard J-Link (no UF2 bootloader), so its overlay links the app
+# straight at flash 0x0 instead of a bootloader-offset partition.
 ZEPHYR_BOARD := $(BOARD)
 ifeq ($(BOARD),aprbrother_nrf52840)
     ZEPHYR_BOARD := nrf52840dongle_nrf52840
+endif
+ifeq ($(BOARD),nrf52840dk)
+    ZEPHYR_BOARD := nrf52840dk/nrf52840
 endif
 
 # Auto-detect NCS toolchain (adds west, cmake, python3, etc. to PATH)
@@ -33,9 +40,15 @@ ifneq ($(NCS_TOOLCHAIN),)
     export PATH := $(NCS_TOOLCHAIN):$(PATH)
 endif
 
-# Build with board-specific overlay and conf if they exist
+# Build with board-specific overlay and conf if they exist. Boards whose
+# board.cmake defines multiple SoC variants (e.g. nrf52840dk covers both
+# nrf52840 and nrf52811) require Zephyr's '<board>_<soc>.conf' naming for the
+# conf file, so try that before falling back to the plain '<board>.conf'.
 OVERLAY := $(wildcard $(shell pwd)/boards/$(BOARD).overlay)
-CONF := $(wildcard $(shell pwd)/boards/$(BOARD).conf)
+CONF := $(wildcard $(shell pwd)/boards/$(BOARD)_nrf52840.conf)
+ifeq ($(CONF),)
+    CONF := $(wildcard $(shell pwd)/boards/$(BOARD).conf)
+endif
 
 # App-specific extra conf (e.g., prj_usb2usb.conf)
 APP_CONF := $(wildcard $(shell pwd)/prj_$(APP_TYPE).conf)

--- a/nrf/boards/nrf52840dk.overlay
+++ b/nrf/boards/nrf52840dk.overlay
@@ -1,0 +1,51 @@
+/* Joypad usb2usb — nRF52840-DK devicetree overlay
+ *
+ * The DK's default DTS (via nrf52840_partition.dtsi) lays out flash for an
+ * MCUboot child image: boot_partition at 0x0, then slot0/slot1 app slots.
+ * The DK has no bootloader here — it flashes straight over the onboard
+ * J-Link — so replace that with a single code_partition at 0x0 spanning the
+ * whole flash, keeping the same NVS storage_partition tail used by
+ * flash_nrf.c / btstack_tlv_nrf.c.
+ *
+ * Console is already zephyr,console = &uart0 in the stock DK devicetree,
+ * routed to the J-Link's onboard VCOM — no console overlay needed.
+ *
+ * display_i2c_nrf.c (shared across all boards, built regardless of app type)
+ * references &i2c1 by devicetree label. The DK's stock dts defines i2c1's
+ * pinctrl but leaves it disabled (commented `status = "okay"`) because it
+ * conflicts with spi1 — enable it here so the node ordinal resolves; no
+ * display is attached for usb2usb.
+ */
+
+&i2c1 {
+	status = "okay";
+};
+
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		code_partition: partition@0 {
+			label = "code_partition";
+			reg = <0x00000000 0x000f8000>;
+		};
+
+		storage_partition: partition@f8000 {
+			label = "storage";
+			reg = <0x000f8000 0x00008000>;
+		};
+	};
+};
+
+/ {
+	chosen {
+		zephyr,code-partition = &code_partition;
+	};
+};

--- a/nrf/boards/nrf52840dk_nrf52840.conf
+++ b/nrf/boards/nrf52840dk_nrf52840.conf
@@ -1,0 +1,8 @@
+# nRF52840-DK board-specific config
+#
+# The DK flashes via its onboard J-Link (no UF2/MCUboot bootloader), so the
+# app links directly at flash 0x0. The overlay replaces the default
+# MCUboot-shaped partitions (boot_partition/slot0/slot1) with a single
+# code_partition spanning the whole flash minus the NVS storage partition.
+CONFIG_USE_DT_CODE_PARTITION=y
+CONFIG_BOOTLOADER_MCUBOOT=n

--- a/nrf/prj_usb2usb.conf
+++ b/nrf/prj_usb2usb.conf
@@ -6,3 +6,7 @@
 # SPI driver disabled — MAX3421E uses direct NRF_SPI1 register access (ISR-safe)
 CONFIG_SPI=n
 CONFIG_BT=n
+
+# uart_host_nrf.c drives the console UART with interrupt-driven RX so
+# joypad-mcp frames aren't dropped while the main loop is busy elsewhere.
+CONFIG_UART_INTERRUPT_DRIVEN=y

--- a/nrf/src/uart_host_nrf.c
+++ b/nrf/src/uart_host_nrf.c
@@ -1,0 +1,321 @@
+// uart_host_nrf.c - UART Host Interface for nRF52840 (Zephyr)
+//
+// Zephyr port of native/host/uart/uart_host.c. Same protocol/state machine
+// and public API (uart_host.h); only the UART transport is Zephyr instead
+// of pico-SDK. Runs on the console UART (uart0) — logs are lines, MCP
+// frames are binary with SYNC+CRC8 framing, exactly like the RP2040 build
+// which shares one UART for both over USB CDC.
+
+#include "uart_host.h"
+#include "core/uart/uart_protocol.h"
+#include "core/router/router.h"
+#include "core/input_event.h"
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/uart.h>
+#include <string.h>
+#include <stdio.h>
+
+// ============================================================================
+// INTERNAL STATE
+// ============================================================================
+
+static bool initialized = false;
+static const struct device *uart_dev;
+static uart_host_mode_t host_mode = UART_HOST_MODE_NORMAL;
+
+// Receive state machine (identical framing to the pico-SDK port)
+typedef enum {
+    RX_STATE_SYNC,
+    RX_STATE_LENGTH,
+    RX_STATE_TYPE,
+    RX_STATE_PAYLOAD,
+    RX_STATE_CRC,
+} rx_state_t;
+
+static rx_state_t rx_state = RX_STATE_SYNC;
+static uint8_t rx_buffer[UART_PROTOCOL_MAX_PAYLOAD + UART_OVERHEAD];
+static uint8_t rx_index = 0;
+static uint8_t rx_length = 0;
+static uint8_t rx_type = 0;
+
+static uint32_t rx_count = 0;
+static uint32_t error_count = 0;
+static uint32_t crc_errors = 0;
+static uint32_t last_rx_time = 0;
+
+static uart_host_profile_callback_t profile_callback = NULL;
+static uart_host_mode_callback_t output_mode_callback = NULL;
+
+// ISR-driven RX ring buffer, same rationale as the pico-SDK port: the
+// main loop can stall (I2C polling, display refresh) longer than the
+// hardware FIFO can absorb at 115200 baud, so drain it in the UART IRQ.
+#define RX_RING_SIZE 1024
+static volatile uint8_t rx_ring[RX_RING_SIZE];
+static volatile uint16_t rx_ring_head = 0;  // written by ISR
+static volatile uint16_t rx_ring_tail = 0;  // read by task
+static volatile uint32_t rx_ring_overflow = 0;
+
+// ============================================================================
+// PACKET PROCESSING
+// ============================================================================
+
+static void process_packet(uint8_t type, const uint8_t *payload, uint8_t len)
+{
+    printf("[uart_host] rx type=0x%02X len=%u\n", type, (unsigned)len);
+    switch (type) {
+        case UART_PKT_NOP:
+            break;
+
+        case UART_PKT_PING:
+            // TODO: Send PONG response via uart_device
+            break;
+
+        case UART_PKT_INPUT_EVENT: {
+            if (len < sizeof(uart_input_event_t)) break;
+
+            const uart_input_event_t *evt = (const uart_input_event_t *)payload;
+            if (evt->player_index >= UART_HOST_MAX_PLAYERS) break;
+
+            input_event_t event;
+            init_input_event(&event);
+
+            event.dev_addr = 0xD0 + evt->player_index;
+            event.instance = 0;
+            event.type = evt->device_type;
+            event.buttons = evt->buttons;
+            event.analog[ANALOG_LX] = evt->analog[0];
+            event.analog[ANALOG_LY] = evt->analog[1];
+            event.analog[ANALOG_RX] = evt->analog[2];
+            event.analog[ANALOG_RY] = evt->analog[3];
+            event.analog[ANALOG_L2] = evt->analog[4];
+            event.analog[ANALOG_R2] = evt->analog[5];
+            event.delta_x = evt->delta_x;
+            event.delta_y = evt->delta_y;
+
+            if (host_mode == UART_HOST_MODE_NORMAL) {
+                router_submit_input(&event);
+            }
+            break;
+        }
+
+        case UART_PKT_INPUT_CONNECT: {
+            if (len < sizeof(uart_connect_event_t)) break;
+            const uart_connect_event_t *conn = (const uart_connect_event_t *)payload;
+            printf("[uart_host] Remote player %d connected (type=%d, VID=%04X, PID=%04X)\n",
+                   conn->player_index, conn->device_type, conn->vid, conn->pid);
+            break;
+        }
+
+        case UART_PKT_INPUT_DISCONNECT: {
+            if (len < sizeof(uart_disconnect_event_t)) break;
+            const uart_disconnect_event_t *disc = (const uart_disconnect_event_t *)payload;
+            printf("[uart_host] Remote player %d disconnected\n", disc->player_index);
+            break;
+        }
+
+        case UART_PKT_SET_PROFILE:
+            if (len >= 1 && profile_callback) {
+                profile_callback(payload[0]);
+            }
+            break;
+
+        case UART_PKT_SET_MODE:
+            if (len >= 1 && output_mode_callback) {
+                output_mode_callback(payload[0]);
+            }
+            break;
+
+        case UART_PKT_VERSION:
+            if (len >= sizeof(uart_version_t)) {
+                const uart_version_t *ver = (const uart_version_t *)payload;
+                printf("[uart_host] Remote version: %d.%d.%d (board=%d, features=0x%08lX)\n",
+                       ver->major, ver->minor, ver->patch, ver->board_type,
+                       (unsigned long)ver->features);
+            }
+            break;
+
+        default:
+            error_count++;
+            break;
+    }
+}
+
+// ============================================================================
+// RECEIVE STATE MACHINE
+// ============================================================================
+
+static void process_rx_byte(uint8_t byte)
+{
+    switch (rx_state) {
+        case RX_STATE_SYNC:
+            if (byte == UART_PROTOCOL_SYNC_BYTE) {
+                rx_buffer[0] = byte;
+                rx_index = 1;
+                rx_state = RX_STATE_LENGTH;
+            } else {
+                static uint32_t junk_count = 0;
+                static uint32_t last_junk_log = 0;
+                junk_count++;
+                uint32_t now = k_uptime_get_32();
+                if (now - last_junk_log > 1000) {
+                    printf("[uart_host] junk: %lu non-sync bytes (last=0x%02X)\n",
+                           (unsigned long)junk_count, (unsigned)byte);
+                    last_junk_log = now;
+                }
+            }
+            break;
+
+        case RX_STATE_LENGTH:
+            rx_length = byte;
+            rx_buffer[rx_index++] = byte;
+            if (rx_length > UART_PROTOCOL_MAX_PAYLOAD) {
+                printf("[uart_host] bad length %u (max %u)\n",
+                       (unsigned)rx_length, (unsigned)UART_PROTOCOL_MAX_PAYLOAD);
+                error_count++;
+                rx_state = RX_STATE_SYNC;
+            } else {
+                rx_state = RX_STATE_TYPE;
+            }
+            break;
+
+        case RX_STATE_TYPE:
+            rx_type = byte;
+            rx_buffer[rx_index++] = byte;
+            rx_state = (rx_length == 0) ? RX_STATE_CRC : RX_STATE_PAYLOAD;
+            break;
+
+        case RX_STATE_PAYLOAD:
+            rx_buffer[rx_index++] = byte;
+            if (rx_index >= UART_HEADER_SIZE + rx_length) {
+                rx_state = RX_STATE_CRC;
+            }
+            break;
+
+        case RX_STATE_CRC: {
+            uint8_t received_crc = byte;
+            uint8_t calculated_crc = uart_crc8(&rx_buffer[1], rx_length + 2);
+
+            if (received_crc == calculated_crc) {
+                rx_count++;
+                last_rx_time = k_uptime_get_32();
+                process_packet(rx_type, &rx_buffer[UART_HEADER_SIZE], rx_length);
+            } else {
+                printf("[uart_host] CRC fail type=0x%02X len=%u got=0x%02X want=0x%02X\n",
+                       (unsigned)rx_type, (unsigned)rx_length,
+                       (unsigned)received_crc, (unsigned)calculated_crc);
+                crc_errors++;
+                error_count++;
+            }
+            rx_state = RX_STATE_SYNC;
+            break;
+        }
+    }
+}
+
+// ============================================================================
+// UART IRQ — drain the hardware FIFO into the software ring buffer
+// ============================================================================
+
+static void uart_host_isr(const struct device *dev, void *user_data)
+{
+    ARG_UNUSED(user_data);
+    while (uart_irq_update(dev) && uart_irq_rx_ready(dev)) {
+        uint8_t b;
+        while (uart_fifo_read(dev, &b, 1) == 1) {
+            uint16_t next = (uint16_t)((rx_ring_head + 1) % RX_RING_SIZE);
+            if (next == rx_ring_tail) {
+                rx_ring_overflow++;
+            } else {
+                rx_ring[rx_ring_head] = b;
+                rx_ring_head = next;
+            }
+        }
+    }
+}
+
+// ============================================================================
+// PUBLIC API
+// ============================================================================
+
+void uart_host_init(void)
+{
+    uart_host_init_pins(UART_HOST_TX_PIN, UART_HOST_RX_PIN, UART_PROTOCOL_BAUD_DEFAULT);
+}
+
+// tx_pin/rx_pin are unused on nRF — the port always uses the board's
+// devicetree-configured UART_HOST_PERIPHERAL (console uart0 by default,
+// pinned via the board overlay), matching how the pico-SDK port's pins
+// are themselves just GPIO_FUNC_UART assignments on a fixed peripheral.
+void uart_host_init_pins(uint8_t tx_pin, uint8_t rx_pin, uint32_t baud)
+{
+    ARG_UNUSED(tx_pin);
+    ARG_UNUSED(rx_pin);
+    ARG_UNUSED(baud);
+
+    printf("[uart_host] Initializing UART host (nRF/Zephyr)\n");
+
+    uart_dev = DEVICE_DT_GET(DT_NODELABEL(UART_HOST_PERIPHERAL));
+    if (!device_is_ready(uart_dev)) {
+        printf("[uart_host] UART device not ready\n");
+        return;
+    }
+
+    rx_state = RX_STATE_SYNC;
+    rx_index = 0;
+    rx_ring_head = rx_ring_tail = 0;
+    rx_ring_overflow = 0;
+
+    uart_irq_callback_user_data_set(uart_dev, uart_host_isr, NULL);
+    uart_irq_rx_enable(uart_dev);
+
+    initialized = true;
+    printf("[uart_host] Initialization complete (IRQ-driven RX, ring=%u)\n",
+           (unsigned)RX_RING_SIZE);
+}
+
+void uart_host_task(void)
+{
+    if (!initialized) return;
+
+    static uint32_t last_overflow_log = 0;
+    while (rx_ring_tail != rx_ring_head) {
+        uint8_t b = rx_ring[rx_ring_tail];
+        rx_ring_tail = (uint16_t)((rx_ring_tail + 1) % RX_RING_SIZE);
+        process_rx_byte(b);
+    }
+    if (rx_ring_overflow > 0) {
+        uint32_t now = k_uptime_get_32();
+        if (now - last_overflow_log > 1000) {
+            printf("[uart_host] ring overflow: %lu bytes dropped\n",
+                   (unsigned long)rx_ring_overflow);
+            rx_ring_overflow = 0;
+            last_overflow_log = now;
+        }
+    }
+}
+
+void uart_host_set_mode(uart_host_mode_t mode) { host_mode = mode; }
+uart_host_mode_t uart_host_get_mode(void) { return host_mode; }
+
+bool uart_host_is_connected(void)
+{
+    if (!initialized) return false;
+    uint32_t now = k_uptime_get_32();
+    return (now - last_rx_time) < 5000;
+}
+
+uint32_t uart_host_get_rx_count(void) { return rx_count; }
+uint32_t uart_host_get_error_count(void) { return error_count; }
+uint32_t uart_host_get_crc_errors(void) { return crc_errors; }
+
+void uart_host_set_profile_callback(uart_host_profile_callback_t callback)
+{
+    profile_callback = callback;
+}
+
+void uart_host_set_output_mode_callback(uart_host_mode_callback_t callback)
+{
+    output_mode_callback = callback;
+}


### PR DESCRIPTION
## What

Ports `src/native/host/uart/uart_host.c` to the nRF52840 Zephyr build (`nrf/`) so `usb2usb` boards can be driven by `joypad-mcp` the same way RP2040/ESP/WCH boards already are.

`uart_host.c` is written against the pico-SDK (`hardware/uart.h`, `UART0_IRQ`, `irq_set_exclusive_handler`) and `nrf/CMakeLists.txt` never defines `CONFIG_UART_HOST` for any app type, so it's currently unreachable from the nRF build.

- `nrf/src/uart_host_nrf.c` — a full re-implementation of `uart_host.h`'s public API (`uart_host_init`, `uart_host_init_pins`, `uart_host_task`, mode/callback setters, stats) on Zephyr's interrupt-driven UART API instead of pico-SDK, with the same protocol state machine (SYNC/LEN/TYPE/PAYLOAD/CRC8) and the same `router_submit_input` path for `UART_PKT_INPUT_EVENT`. Runs on the console UART (`uart0`) — logs are lines, MCP frames are binary, mirroring how the RP2040 build shares one UART for both over USB CDC.
- `nrf/CMakeLists.txt` — adds the new file and `CONFIG_UART_HOST=1` / `UART_HOST_PERIPHERAL=uart0` for `APP_TYPE=usb2usb` only, following the existing per-app-type pattern. Off by default for `bt2usb`/`btusb2usb`/`controller_btusb`/`mouthpad`.
- `nrf/prj_usb2usb.conf` — adds `CONFIG_UART_INTERRUPT_DRIVEN=y` so RX isn't dropped while the main loop is busy elsewhere (same rationale as the pico-SDK port's ring buffer).

`src/native/host/uart/uart_host.c` and every RP2040/ESP/WCH build target are untouched.

## Validation

Built `usb2usb` for the Adafruit Feather nRF52840 (NCS v3.1.0) and ran the firmware end-to-end on a full-system nRF52840 simulator: the ELF booted, USB enumerated to Configured against a simulated USB host, and joypad-mcp's own (unmodified) transport code opened a serial connection to the console UART and exchanged the same boot banner / `INPUT_EVENT` frames it uses on hardware.

```
*** Booting nRF Connect SDK v3.1.0-6c6e5b32496e ***
*** Using Zephyr OS v4.1.99-1612683d4010 ***
[joypad] Starting usb2usb on Adafruit Feather nRF52840...
...
[uart_host] Initializing UART host (nRF/Zephyr)
[uart_host] Initialization complete (IRQ-driven RX, ring=1024)
[app:usb2usb] Initialization complete
...
[joypad] Entering main loop
```

joypad-mcp's `Connection` opened the console UART and sent the same `INPUT_EVENT` press/release pair its `tap` tool emits; the simulator's UART model delivered the framed bytes to the firmware's RX interrupt and they were correctly parsed (SYNC/LEN/TYPE matched, CRC8 validated) into a queued `INPUT_EVENT`, confirming the Zephyr transport (IRQ registration, FIFO drain, ring buffer, state machine) is wired correctly end to end at the byte level.

The final "queued event reaches the router and shows up as a HID report bit" step is not yet confirmed in this simulator, independent of this port: the simulated board's main loop stops calling any of its periodic tasks (including `uart_host_task`) shortly after boot on this specific SoC/board configuration, which I could reproduce identically on the *unmodified* upstream `usb2usb` firmware with zero UART changes — so it's a pre-existing simulator/platform gap, not something introduced here. I'll follow up separately once that's resolved; happy to extend the PR with a full tap-to-HID transcript at that point if useful.

## Notes for maintainers

- Building the nrf/ tree needs `git submodule update --init libxsm3 tinyusb tusb_xinput pico-sdk` before `west build` — worth a line in the nRF build docs if it isn't there already, since none of those are nRF-specific but the build fails without them.
- I kept pins as inert `CONFIG_UART_HOST_TX_PIN`/`RX_PIN` defines only because `usb2usb/app.c` references them unconditionally under `#ifdef CONFIG_UART_HOST` — the nRF port ignores them and always uses the devicetree-configured UART (matching how the RP2040 build's own pins are just `GPIO_FUNC_UART` assignments on a fixed peripheral). Let me know if you'd rather see that guarded differently.
- Happy to adjust naming, file placement, or squash to match your conventions — this is my first PR here.
