### PR TITLE
fix(ws2812): RGB byte order for Waveshare RP2350-USB-A

### DIFF
--- a/src/core/services/leds/neopixel/ws2812.c
+++ b/src/core/services/leds/neopixel/ws2812.c
@@ -20,6 +20,8 @@
 #ifndef IS_RGBW
   #ifdef ADAFRUIT_MACROPAD_RP2040
     #define IS_RGBW false  // MacroPad uses WS2812B (RGB, not RGBW)
+  #elif defined(WAVESHARE_RP2350_USB_A)
+    #define IS_RGBW false  // Waveshare RP2350-USB-A uses WS2812B (RGB, not RGBW)
   #else
     #define IS_RGBW true
   #endif
@@ -76,10 +78,18 @@ static inline void put_pixel(uint32_t pixel_grb) {
 }
 
 static inline uint32_t urgb_u32(uint8_t r, uint8_t g, uint8_t b) {
+#ifdef WAVESHARE_RP2350_USB_A
+    // Waveshare RP2350-USB-A WS2812 uses RGB byte order
+    return
+            ((uint32_t) (r) << 16) |
+            ((uint32_t) (g) << 8) |
+            (uint32_t) (b);
+#else
     return
             ((uint32_t) (r) << 8) |
             ((uint32_t) (g) << 16) |
             (uint32_t) (b);
+#endif
 }
 
 void pattern_snakes(uint len, uint t) {


### PR DESCRIPTION
## Summary
The Waveshare RP2350-USB-A board uses a WS2812B LED that expects
RGB byte order and is not an RGBW LED. The default driver assumed
GRB order (and RGBW for non-MacroPad boards), which made the onboard
LED render wrong colors.

This fix scopes the correct byte order and IS_RGBW=false to the
Waveshare RP2350-USB-A via its board define, leaving every other
board untouched.

## Changes
- `ws2812.c`: define `IS_RGBW` as `false` when building for
  `WAVESHARE_RP2350_USB_A` (WS2812B is RGB, not RGBW).
- `ws2812.c`: return RGB byte order in `urgb_u32()` under
  `#ifdef WAVESHARE_RP2350_USB_A`; the default GRB path is unchanged
  for all other boards.

## Testing
- Built and flashed on the Waveshare RP2350-USB-A: LED colors now
  correct.
- The change is compile-time guarded by `WAVESHARE_RP2350_USB_A`
  (defined only by that board's pico-sdk header), so other boards
  (Pico, Pico 2, ESP32, nRF, WCH) take the original code path.