### PR TITLE
feat(bt): add iPega PG-9021 classic Bluetooth gamepad driver

### DIFF
--- a/esp/main/CMakeLists.txt
+++ b/esp/main/CMakeLists.txt
@@ -361,6 +361,7 @@ if(APP_NEEDS_BTSTACK)
             "${SHARED_SRC}/bt/bthid/devices/vendors/augmental/mouthpad_ble.c"
             "${SHARED_SRC}/bt/bthid/devices/vendors/valve/steam_controller_2_ble.c"
             "${SHARED_SRC}/bt/bthid/devices/vendors/valve/steam_controller_ble.c"
+            "${SHARED_SRC}/bt/bthid/devices/vendors/ipega/ipega_bt.c"
 
             # BTstack host + transport
             "${SHARED_SRC}/bt/btstack/btstack_host.c"

--- a/nrf/CMakeLists.txt
+++ b/nrf/CMakeLists.txt
@@ -286,6 +286,7 @@ elseif(APP_TYPE STREQUAL "btusb2usb")
         "${SHARED_SRC}/bt/bthid/devices/vendors/valve/steam_controller_2_ble.c"
         "${SHARED_SRC}/bt/bthid/devices/vendors/valve/steam_controller_ble.c"
         "${SHARED_SRC}/bt/bthid/devices/vendors/augmental/mouthpad_ble.c"
+        "${SHARED_SRC}/bt/bthid/devices/vendors/ipega/ipega_bt.c"
 
         # --- BTstack host + transport ---
         "${SHARED_SRC}/bt/btstack/btstack_host.c"
@@ -427,6 +428,7 @@ elseif(APP_TYPE STREQUAL "controller_btusb")
         "${SHARED_SRC}/bt/bthid/devices/vendors/valve/steam_controller_2_ble.c"
         "${SHARED_SRC}/bt/bthid/devices/vendors/valve/steam_controller_ble.c"
         "${SHARED_SRC}/bt/bthid/devices/vendors/augmental/mouthpad_ble.c"
+        "${SHARED_SRC}/bt/bthid/devices/vendors/ipega/ipega_bt.c"
 
         # --- nRF BTstack TLV ---
         "src/btstack_tlv_nrf.c"
@@ -598,6 +600,7 @@ else()
         "${SHARED_SRC}/bt/bthid/devices/vendors/valve/steam_controller_2_ble.c"
         "${SHARED_SRC}/bt/bthid/devices/vendors/valve/steam_controller_ble.c"
         "${SHARED_SRC}/bt/bthid/devices/vendors/augmental/mouthpad_ble.c"
+        "${SHARED_SRC}/bt/bthid/devices/vendors/ipega/ipega_bt.c"
 
         # --- BTstack host + transport ---
         "${SHARED_SRC}/bt/btstack/btstack_host.c"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -188,6 +188,7 @@ set(BTHID_DEVICE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/bt/bthid/devices/vendors/valve/steam_controller_2_ble.c
     ${CMAKE_CURRENT_SOURCE_DIR}/bt/bthid/devices/vendors/valve/steam_controller_ble.c
     ${CMAKE_CURRENT_SOURCE_DIR}/bt/bthid/devices/vendors/augmental/mouthpad_ble.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/bt/bthid/devices/vendors/ipega/ipega_bt.c
     # MouthPad NUS<->CDC relay (ambient: self-attaches to CDC when linked + a
     # MouthPad is connected; inert otherwise). Companion to the mouthpad_ble HID
     # driver so every BLE app gains MouthPad support without a dedicated app.

--- a/src/bt/bthid/bthid.c
+++ b/src/bt/bthid/bthid.c
@@ -83,15 +83,6 @@ void bthid_register_driver(const bthid_driver_t* driver)
 
 static bool bthid_task_debug_done = false;
 static bool bt_on_hid_report_debug_done = false;
-// Debug dump of raw HID reports/descriptors (reverse-engineering layouts like
-// the iPega PG-9021). Disabled in release builds - enable to capture layouts.
-// #define BTHID_DEBUG_DUMP 1
-#ifdef BTHID_DEBUG_DUMP
-static uint8_t bthid_conn_report_dumps[BTHID_MAX_DEVICES]; // full reports dumped per conn
-static uint8_t raw_last[BTHID_MAX_DEVICES][64];
-static uint16_t raw_last_len[BTHID_MAX_DEVICES];
-static uint32_t raw_changed_count[BTHID_MAX_DEVICES];
-#endif
 
 void bthid_task(void)
 {
@@ -436,10 +427,6 @@ void bt_on_disconnect(uint8_t conn_index)
         cached_hid_desc_len = 0;
         cached_hid_desc_conn = 0xFF;
     }
-#ifdef BTHID_DEBUG_DUMP
-    bthid_conn_report_dumps[conn_index] = 0;
-    raw_last_len[conn_index] = 0;   // next connection re-dumps first report
-#endif
     remove_device(conn_index);
 
     // Reset one-shot debug flags so reconnections produce debug output
@@ -466,25 +453,7 @@ void bt_on_hid_report(uint8_t conn_index, const uint8_t* data, uint16_t len)
         return;
     }
 
-#ifdef BTHID_DEBUG_DUMP
-    // Dump changed HID input reports unparsed (dedupe consecutive identical so
-    // presses/releases are visible). Reverse-engineers the PG-9021 layout in
-    // XInput/PS3/PS4/Switch/Steam modes: play each control and capture lines.
-    bool raw_same = (bthid_conn_report_dumps[conn_index] > 0) &&
-                    (len == raw_last_len[conn_index] && len <= 64 &&
-                     memcmp(raw_last[conn_index], data, len) == 0);
-    if (!raw_same && raw_changed_count[conn_index] < 200 && len <= 64) {
-        if (len > 0) memcpy(raw_last[conn_index], data, len);
-        raw_last_len[conn_index] = len;
-        raw_changed_count[conn_index]++;
-        bthid_conn_report_dumps[conn_index] = 1;
-        printf("[BTHID] Raw conn=%d len=%d:", conn_index, len);
-        for (uint16_t i = 0; i < len && i < 40; i++) printf(" %02x", data[i]);
-        printf("\n");
-    }
-#endif
-
-    // Debug first report after (re)connection
+// Debug first report after (re)connection
     if (!bt_on_hid_report_debug_done) {
         printf("[BTHID] First report: conn=%d, len=%d, data[0]=0x%02X\n",
                conn_index, len, data[0]);
@@ -547,25 +516,7 @@ void bt_on_hid_report(uint8_t conn_index, const uint8_t* data, uint16_t len)
 
 void bthid_set_hid_descriptor(uint8_t conn_index, const uint8_t* desc, uint16_t desc_len)
 {
-#ifdef BTHID_DEBUG_DUMP
-    // Dump the HID report descriptor hex whenever a NEW descriptor arrives for
-    // this connection. This reveals the exact per-mode byte layout of the
-    // PG-9021 (Android HID vs XInput vs PS3 vs PS4 vs Switch vs Steam Input).
-    static uint8_t desc_conn_last = 0xFF;
-    static uint16_t desc_len_last = 0;
-    if (desc_conn_last != conn_index || desc_len_last != desc_len) {
-        desc_conn_last = conn_index;
-        desc_len_last = desc_len;
-        printf("[BTHID] HID desc conn=%d len=%u:", conn_index, (unsigned)desc_len);
-        for (uint16_t i = 0; i < desc_len && i < 256; i++) {
-            if ((i % 16) == 0) printf("\n  ");
-            printf("%02x ", desc[i]);
-        }
-        printf("\n");
-    }
-#endif
-
-    // Always cache — descriptor often arrives before device is created (Classic BT)
+// Always cache — descriptor often arrives before device is created (Classic BT)
     if (desc_len <= BTHID_MAX_DESC_LEN) {
         memcpy(cached_hid_desc, desc, desc_len);
         cached_hid_desc_len = desc_len;

--- a/src/bt/bthid/bthid.c
+++ b/src/bt/bthid/bthid.c
@@ -83,6 +83,15 @@ void bthid_register_driver(const bthid_driver_t* driver)
 
 static bool bthid_task_debug_done = false;
 static bool bt_on_hid_report_debug_done = false;
+// Debug dump of raw HID reports/descriptors (reverse-engineering layouts like
+// the iPega PG-9021). Disabled in release builds - enable to capture layouts.
+// #define BTHID_DEBUG_DUMP 1
+#ifdef BTHID_DEBUG_DUMP
+static uint8_t bthid_conn_report_dumps[BTHID_MAX_DEVICES]; // full reports dumped per conn
+static uint8_t raw_last[BTHID_MAX_DEVICES][64];
+static uint16_t raw_last_len[BTHID_MAX_DEVICES];
+static uint32_t raw_changed_count[BTHID_MAX_DEVICES];
+#endif
 
 void bthid_task(void)
 {
@@ -427,6 +436,10 @@ void bt_on_disconnect(uint8_t conn_index)
         cached_hid_desc_len = 0;
         cached_hid_desc_conn = 0xFF;
     }
+#ifdef BTHID_DEBUG_DUMP
+    bthid_conn_report_dumps[conn_index] = 0;
+    raw_last_len[conn_index] = 0;   // next connection re-dumps first report
+#endif
     remove_device(conn_index);
 
     // Reset one-shot debug flags so reconnections produce debug output
@@ -452,6 +465,24 @@ void bt_on_hid_report(uint8_t conn_index, const uint8_t* data, uint16_t len)
         }
         return;
     }
+
+#ifdef BTHID_DEBUG_DUMP
+    // Dump changed HID input reports unparsed (dedupe consecutive identical so
+    // presses/releases are visible). Reverse-engineers the PG-9021 layout in
+    // XInput/PS3/PS4/Switch/Steam modes: play each control and capture lines.
+    bool raw_same = (bthid_conn_report_dumps[conn_index] > 0) &&
+                    (len == raw_last_len[conn_index] && len <= 64 &&
+                     memcmp(raw_last[conn_index], data, len) == 0);
+    if (!raw_same && raw_changed_count[conn_index] < 200 && len <= 64) {
+        if (len > 0) memcpy(raw_last[conn_index], data, len);
+        raw_last_len[conn_index] = len;
+        raw_changed_count[conn_index]++;
+        bthid_conn_report_dumps[conn_index] = 1;
+        printf("[BTHID] Raw conn=%d len=%d:", conn_index, len);
+        for (uint16_t i = 0; i < len && i < 40; i++) printf(" %02x", data[i]);
+        printf("\n");
+    }
+#endif
 
     // Debug first report after (re)connection
     if (!bt_on_hid_report_debug_done) {
@@ -516,6 +547,24 @@ void bt_on_hid_report(uint8_t conn_index, const uint8_t* data, uint16_t len)
 
 void bthid_set_hid_descriptor(uint8_t conn_index, const uint8_t* desc, uint16_t desc_len)
 {
+#ifdef BTHID_DEBUG_DUMP
+    // Dump the HID report descriptor hex whenever a NEW descriptor arrives for
+    // this connection. This reveals the exact per-mode byte layout of the
+    // PG-9021 (Android HID vs XInput vs PS3 vs PS4 vs Switch vs Steam Input).
+    static uint8_t desc_conn_last = 0xFF;
+    static uint16_t desc_len_last = 0;
+    if (desc_conn_last != conn_index || desc_len_last != desc_len) {
+        desc_conn_last = conn_index;
+        desc_len_last = desc_len;
+        printf("[BTHID] HID desc conn=%d len=%u:", conn_index, (unsigned)desc_len);
+        for (uint16_t i = 0; i < desc_len && i < 256; i++) {
+            if ((i % 16) == 0) printf("\n  ");
+            printf("%02x ", desc[i]);
+        }
+        printf("\n");
+    }
+#endif
+
     // Always cache — descriptor often arrives before device is created (Classic BT)
     if (desc_len <= BTHID_MAX_DESC_LEN) {
         memcpy(cached_hid_desc, desc, desc_len);

--- a/src/bt/bthid/bthid_registry.c
+++ b/src/bt/bthid/bthid_registry.c
@@ -18,6 +18,7 @@
 #include "devices/vendors/valve/steam_controller_2_ble.h"
 #include "devices/vendors/valve/steam_controller_ble.h"
 #include "devices/vendors/augmental/mouthpad_ble.h"
+#include "devices/vendors/ipega/ipega_bt.h"
 #include "devices/generic/sinput_ble.h"
 
 void bthid_registry_init(void)
@@ -56,6 +57,11 @@ void bthid_registry_init(void)
 
     // Augmental MouthPad (BLE mouse/keyboard/consumer — matches by name)
     mouthpad_ble_register();
+
+    // iPega PG-9021 (classic BT gamepad, VID 0x1949 / PID 0x0404 BT).
+    // Registered before the generic fallback so its 11-byte RID-7 report is
+    // decoded deterministically instead of relying on HID descriptor parsing.
+    ipega_bt_register();
 
     // JoypadOS SInput controller over BLE (matches by VID/PID 2E8A:10C6 or name).
     // Must register before the generic fallback so SInput's report ID 1 is parsed

--- a/src/bt/bthid/devices/vendors/ipega/ipega_bt.c
+++ b/src/bt/bthid/devices/vendors/ipega/ipega_bt.c
@@ -1,0 +1,327 @@
+// ipega_bt.c - iPega PG-9021 Bluetooth gamepad driver
+//
+// The PG-9021 pairs over classic Bluetooth and reports as a USB HID gamepad
+// (VID 0x1949 / PID 0x0404 in BT mode, 0x0402 wired; BT name "HID GamePad").
+// It sends an 11-byte input report with Report ID 7.
+//
+// Layout — matching the user-provided spec (standard Android/PC mode layout; the pad's bytes
+// are NOT swapped vs the usage names):
+//
+//   [0]  = 0x07 (Report ID)
+//   [1]  = LX    left stick X,  0-255, center 128
+//   [2]  = LY    left stick Y,  0-255, center 128
+//   [3]  = RX    right stick X, 0-255, center 128
+//   [4]  = RY    right stick Y, 0-255, center 128
+//   [5]  = HAT   switch, 4-bit (0-7 = N..NW, 0x0F = neutral)
+//   [6]  = buttons: A=bit0, B=bit1, X=bit3, Y=bit4, LB=bit6, RB=bit7
+//   [7]  = Select=bit2, Start=bit3, L3=bit5, R3=bit6
+//   [8]  = RT    right trigger analog (0-255)
+//   [9]  = LT    left trigger analog (0-255)
+//   [10] = counter / varies (ignored)
+//
+// Home lives in the separate Consumer Control interface (Report ID 2, byte1
+// bit7 = 0x80 pressed / 0x00 released). It maps to JP_BUTTON_A1 with an
+// edge + auto-release timeout so it can never stay stuck pressed, even on
+// modes that stop sending the release report.
+//
+// Note: byte6 bit0 (A) may read active at rest on some units - check whether
+// the button is physically held down (e.g. by a clip) before touching the
+// decoder.
+
+#include "ipega_bt.h"
+#include "bt/bthid/bthid.h"
+#include "core/input_event.h"
+#include "core/router/router.h"
+#include "core/buttons.h"
+#include "core/services/players/manager.h"
+#include "core/services/players/feedback.h"
+#include <string.h>
+#include <stdio.h>
+
+// ============================================================================
+// iPega IDs
+// ============================================================================
+
+#define IPEGA_VID           0x1949
+#define IPEGA_PID_BT        0x0404   // BT mode
+#define IPEGA_PID_USB       0x0402   // wired (defensive match with name)
+
+#define IPEGA_REPORT_ID     0x07     // gamepad input report ID
+#define IPEGA_REPORT_LEN    11       // full report including report ID byte
+#define IPEGA_REPORT_ID_HOME 0x02    // Consumer Control (Home = byte1 bit7)
+#define IPEGA_HOME_AUTOFADE 60       // reports w/o fresh press => auto-release (~300ms)
+
+// ============================================================================
+// BUTTON BIT MASKS (16-bit field at bytes 6-7)
+// ============================================================================
+
+#define IPEGA_BTN_A         0x0001
+#define IPEGA_BTN_B         0x0002
+#define IPEGA_BTN_X         0x0008
+#define IPEGA_BTN_Y         0x0010
+#define IPEGA_BTN_L1        0x0040
+#define IPEGA_BTN_R1        0x0080
+#define IPEGA_BTN_BACK      0x0400
+#define IPEGA_BTN_START     0x0800
+#define IPEGA_BTN_L3        0x2000
+#define IPEGA_BTN_R3        0x4000
+
+// ============================================================================
+// HAT SWITCH LOOKUP (0=N, 1=NE, 2=E, 3=SE, 4=S, 5=SW, 6=W, 7=NW)
+// Returns packed dpad bits: bit0=up, bit1=right, bit2=down, bit3=left
+// ============================================================================
+
+static const uint8_t IPEGA_HAT_TO_DPAD[] = {
+    0b0001, 0b0011, 0b0010, 0b0110, 0b0100, 0b1100, 0b1000, 0b1001
+};
+
+// ============================================================================
+// DRIVER DATA
+// ============================================================================
+
+typedef struct {
+    input_event_t event;
+    bool initialized;
+    bool first_report_dumped;
+    bool home_pending;
+    uint16_t home_no_refresh;
+} ipega_bt_data_t;
+
+static ipega_bt_data_t ipega_data[BTHID_MAX_DEVICES];
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+static bool ipega_name_confirms_model(const char* device_name);
+
+static bool ci_strstr(const char* haystack, const char* needle)
+{
+    if (!haystack || !needle || !haystack[0] || !needle[0]) {
+        return false;
+    }
+    size_t needle_len = strlen(needle);
+    for (const char* p = haystack; p[0]; p++) {
+        size_t i = 0;
+        while (i < needle_len && p[i] &&
+               (p[i] == needle[i] ||
+                (p[i] >= 'A' && p[i] <= 'Z' && p[i] + 32 == needle[i]) ||
+                (needle[i] >= 'A' && needle[i] <= 'Z' && p[i] == needle[i] + 32))) {
+            i++;
+        }
+        if (i == needle_len) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// ============================================================================
+// DRIVER IMPLEMENTATION
+// ============================================================================
+
+static bool ipega_match(const char* device_name, const uint8_t* class_of_device,
+                        uint16_t vendor_id, uint16_t product_id, bool is_ble)
+{
+    (void)class_of_device;
+    (void)is_ble;
+
+    // iPega VID 0x1949 with either iPega PID identifies the PG-9021 family.
+    // The pad may advertise any name over a generic BT dongle (commonly
+    // "HID GamePad"), so match on VID/PID alone - DO NOT require the model
+    // in the name, otherwise the generic driver grabs it and mis-maps it.
+    if (vendor_id == IPEGA_VID &&
+        (product_id == IPEGA_PID_BT || product_id == IPEGA_PID_USB)) {
+        return true;
+    }
+
+    // Some stacks never resolve VID/PID (no SDP Device ID) - rely on name.
+    if (ipega_name_confirms_model(device_name)) {
+        return true;
+    }
+
+    return false;
+}
+
+static bool ipega_name_confirms_model(const char* device_name)
+{
+    if (!device_name || !device_name[0]) {
+        return false;
+    }
+    if (ci_strstr(device_name, "PG-9021")) {
+        return true;
+    }
+    if (ci_strstr(device_name, "9021")) {
+        return true;
+    }
+    if (ci_strstr(device_name, "ipega classic gamepad")) {
+        return true;
+    }
+    return false;
+}
+
+static bool ipega_init(bthid_device_t* device)
+{
+    printf("[IPEGA_BT] Init for device: %s\n", device->name);
+
+    for (int i = 0; i < BTHID_MAX_DEVICES; i++) {
+        if (!ipega_data[i].initialized) {
+            init_input_event(&ipega_data[i].event);
+            ipega_data[i].initialized = true;
+            ipega_data[i].first_report_dumped = false;
+
+            ipega_data[i].event.type = INPUT_TYPE_GAMEPAD;
+            ipega_data[i].event.transport = device->is_ble ?
+                INPUT_TRANSPORT_BT_BLE : INPUT_TRANSPORT_BT_CLASSIC;
+            ipega_data[i].event.dev_addr = device->conn_index;
+            ipega_data[i].event.instance = 0;
+
+            device->driver_data = &ipega_data[i];
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static void ipega_process_report(bthid_device_t* device, const uint8_t* data, uint16_t len)
+{
+    ipega_bt_data_t* id = (ipega_bt_data_t*)device->driver_data;
+    if (!id) return;
+
+    // Dump the first report of every connection. Because each PG-9021 console
+    // mode (XInput/PS3/PS4/Switch) uses a different report layout, connect the
+    // pad in each mode and capture this line to reverse-engineer the mapping.
+    if (!id->first_report_dumped) {
+        id->first_report_dumped = true;
+        printf("[IPEGA_BT] Report (%d bytes):", len);
+        for (int i = 0; i < len && i < 20; i++) printf(" %02x", data[i]);
+        printf("\n");
+    }
+
+    // Consumer Control report (RID 2): byte1 bit7 (0x80) = Home pressed,
+    // 0x00 = released. Only flips the pending flag here - the button is
+    // applied on the next gamepad report so the event has a single submit.
+    // Auto-release (fade) happens in the gamepad path to avoid a stuck Home.
+    if (data[0] == IPEGA_REPORT_ID_HOME && len >= 2) {
+        if (data[1] & 0x80) {
+            id->home_pending = true;
+            id->home_no_refresh = 0;
+        } else {
+            id->home_pending = false;
+        }
+        return;
+    }
+
+    // Only the gamepad input report (RID 7, 11 bytes) is decoded here.
+    if (len < IPEGA_REPORT_LEN || data[0] != IPEGA_REPORT_ID) {
+        return;
+    }
+
+    // Analog sticks (native HID: 0=min, 128=center, 255=max)
+    // Mapping per the user-provided spec (standard HID layout of the PG-9021's
+    // Android/PC mode): byte1=LX, byte2=LY, byte3=RX, byte4=RY.
+    uint8_t lx = data[1];   // left stick X
+    uint8_t ly = data[2];   // left stick Y
+    uint8_t rx = data[3];   // right stick X
+    uint8_t ry = data[4];   // right stick Y
+    uint8_t lt = data[9];   // LT (left trigger)
+    uint8_t rt = data[8];   // RT (right trigger)
+
+    uint16_t buttons = (uint16_t)data[6] | ((uint16_t)data[7] << 8);
+    uint32_t b = 0;
+
+    // D-pad (4-bit hat switch; 0x0F = neutral)
+    uint8_t hat = data[5] & 0x0F;
+    if (hat < 8) {
+        uint8_t dpad = IPEGA_HAT_TO_DPAD[hat];
+        if (dpad & 0x01) b |= JP_BUTTON_DU;
+        if (dpad & 0x02) b |= JP_BUTTON_DR;
+        if (dpad & 0x04) b |= JP_BUTTON_DD;
+        if (dpad & 0x08) b |= JP_BUTTON_DL;
+    }
+
+    // Face / shoulder / system buttons
+    if (buttons & IPEGA_BTN_A)    b |= JP_BUTTON_B1;   // A
+    if (buttons & IPEGA_BTN_B)    b |= JP_BUTTON_B2;   // B
+    if (buttons & IPEGA_BTN_X)    b |= JP_BUTTON_B3;   // X
+    if (buttons & IPEGA_BTN_Y)    b |= JP_BUTTON_B4;   // Y
+    if (buttons & IPEGA_BTN_L1)   b |= JP_BUTTON_L1;   // L1
+    if (buttons & IPEGA_BTN_R1)   b |= JP_BUTTON_R1;   // R1
+    if (buttons & IPEGA_BTN_BACK) b |= JP_BUTTON_S1;   // Back/Select
+    if (buttons & IPEGA_BTN_START) b |= JP_BUTTON_S2;  // Start
+    if (buttons & IPEGA_BTN_L3)   b |= JP_BUTTON_L3;   // L3
+    if (buttons & IPEGA_BTN_R3)   b |= JP_BUTTON_R3;   // R3
+
+    // Home (A1) comes from the Consumer Control report. Auto-release after
+    // IPEGA_HOME_AUTOFADE reports without a fresh press so it can never stay
+    // stuck pressed, even if a mode stops sending the release report.
+    if (id->home_pending) {
+        b |= JP_BUTTON_A1;
+        if (++id->home_no_refresh >= IPEGA_HOME_AUTOFADE) {
+            id->home_pending = false;
+        }
+    }
+
+    id->event.buttons = b;
+    id->event.button_count = 10;
+    id->event.analog[ANALOG_LX] = lx;
+    id->event.analog[ANALOG_LY] = ly;
+    id->event.analog[ANALOG_RX] = rx;
+    id->event.analog[ANALOG_RY] = ry;
+    id->event.analog[ANALOG_L2] = lt;
+    id->event.analog[ANALOG_R2] = rt;
+
+    router_submit_input(&id->event);
+}
+
+static void ipega_task(bthid_device_t* device)
+{
+    // PG-9021 has no rumble support - just consume pending feedback state so
+    // the player feedback system does not keep a stale dirty flag.
+    ipega_bt_data_t* id = (ipega_bt_data_t*)device->driver_data;
+    if (!id) return;
+
+    int player_idx = find_player_index(id->event.dev_addr, id->event.instance);
+    if (player_idx < 0) return;
+
+    feedback_state_t* fb = feedback_get_state(player_idx);
+    if (!fb || !fb->rumble_dirty) return;
+    feedback_clear_dirty(player_idx);
+}
+
+static void ipega_disconnect(bthid_device_t* device)
+{
+    printf("[IPEGA_BT] Disconnect: %s\n", device->name);
+
+    ipega_bt_data_t* id = (ipega_bt_data_t*)device->driver_data;
+    if (id) {
+        // Clear router state first (sends zeroed input report)
+        router_device_disconnected(id->event.dev_addr, id->event.instance);
+        // Remove player assignment
+        remove_players_by_address(id->event.dev_addr, id->event.instance);
+
+        init_input_event(&id->event);
+        id->initialized = false;
+        id->home_pending = false;
+        id->home_no_refresh = 0;
+    }
+}
+
+// ============================================================================
+// DRIVER STRUCT
+// ============================================================================
+
+const bthid_driver_t ipega_bt_driver = {
+    .name = "iPega PG-9021 BT",
+    .match = ipega_match,
+    .init = ipega_init,
+    .process_report = ipega_process_report,
+    .task = ipega_task,
+    .disconnect = ipega_disconnect,
+};
+
+void ipega_bt_register(void)
+{
+    bthid_register_driver(&ipega_bt_driver);
+}

--- a/src/bt/bthid/devices/vendors/ipega/ipega_bt.h
+++ b/src/bt/bthid/devices/vendors/ipega/ipega_bt.h
@@ -1,0 +1,16 @@
+// ipega_bt.h - iPega PG-9021 Bluetooth gamepad driver
+#ifndef IPEGA_BT_H
+#define IPEGA_BT_H
+
+#include "bt/bthid/bthid.h"
+
+// iPega PG-9021 (classic Bluetooth gamepad)
+// VID: 0x1949 (IPEGA)
+// PID: 0x0404 in BT mode (0x0402 when wired)
+// Advertised name: "PG-9021" / "ipega classic gamepad"
+
+extern const bthid_driver_t ipega_bt_driver;
+
+void ipega_bt_register(void);
+
+#endif // IPEGA_BT_H


### PR DESCRIPTION
## Summary
Adds a dedicated BT HID driver for the iPega PG-9021 (VID 0x1949,
PID 0x0404 BT / 0x0402 wired). It decodes the pad's 11-byte Report
ID 7 deterministically instead of relying on the generic HID parser,
which mis-maps its stick/trigger layout.

## Changes
- `ipega_bt.c/h`: new driver — matches by VID/PID (name fallback for
  stacks without Device ID SDP), decodes sticks, triggers, hat switch
  and buttons, plus Home (A1) via the Consumer Control report with a
  stuck-key auto-release.
- `bthid_registry.c`: register the driver before the generic fallback.
- `src/CMakeLists.txt` + `nrf/CMakeLists.txt`: build the driver on
  RP2040 and all three nRF BT targets.

## Verification
- **Tested on the actual iPega PG-9021 and working.**
- Compiled in RP2040 builds.
- Driver registered on nRF BT targets (btusb2usb, controller_btusb,
  bt2usb) — fixes the previous `undefined reference to ipega_bt_register`.

## Notes
- Has no rumble support; task routine just clears stale feedback flags.
- Edge + auto-release guarantees Home can never stay stuck pressed.
- This change was developed with opencode.