### PR TITLE
fix(bt): query PnP SDP on the hid_host path so DualSense binds correctly

### DIFF
--- a/src/bt/btstack/btstack_host.c
+++ b/src/bt/btstack/btstack_host.c
@@ -277,6 +277,12 @@ static void switch2_cleanup_on_disconnect(void);
 
 #define MAX_CLASSIC_CONNECTIONS 4
 #define INQUIRY_DURATION 5  // Inquiry duration in 1.28s units
+// Number of active Classic links. Distinct from
+// btstack_classic_get_connection_count(), which deliberately sums Classic AND
+// BLE for LED/status purposes; decisions about Classic scanning must not be
+// influenced by an unrelated BLE peer.
+static uint8_t classic_link_count(void);
+
 #define CLASSIC_CONNECT_TIMEOUT_MS 15000  // Max time to establish HID connection
 
 typedef struct {
@@ -1337,8 +1343,13 @@ void btstack_host_process(void)
         !hid_state.scan_active &&
         classic_state.waiting_for_incoming_time == 0 &&
         !classic_state.pending_valid &&
-        btstack_classic_get_connection_count() == 0) {
-        printf("[BTSTACK_HOST] Safety: idle with no connections, resuming scan\n");
+        // Classic links only. The combined count includes BLE, so one
+        // unrelated BLE HID device in range (a TV remote, a keyboard) holds
+        // this gate shut forever: Classic inquiry never resumes, and since the
+        // Classic auto-connect path is gated on classic_state.inquiry_active, a
+        // bonded Classic pad can then never be rediscovered after it powers off.
+        classic_link_count() == 0) {
+        printf("[BTSTACK_HOST] Safety: idle with no Classic links, resuming scan\n");
         btstack_host_start_scan();
     }
 #endif
@@ -5459,6 +5470,28 @@ static void hid_host_packet_handler(uint8_t packet_type, uint16_t channel, uint8
             if (conn) {
                 conn->hid_ready = true;
 
+                // PnP (Device ID) SDP query for the hid_host path.
+                //
+                // The only other call site is gated on
+                //     classic_state.pending_hid_connect && wiimote_conn.active
+                // i.e. the direct-L2CAP path, so a pad that comes up through
+                // HID Host is never queried and product_id stays 0. The
+                // remote-name handler then fills in vendor_id from the name
+                // profile default while bt_device_wiimote_pid_from_name()
+                // returns 0 for non-Wiimotes, leaving 054C:0000 for a
+                // DualSense -- which ds5_match() rejects, so the looser
+                // ds4_match() claims it and the pad produces no input.
+                if (conn->product_id == 0) {
+                    memcpy(classic_state.pending_addr, conn->addr, 6);
+                    classic_state.pending_vid = 0;
+                    classic_state.pending_pid = 0;
+                    uint8_t sdp_rc = sdp_client_query_uuid16(
+                        &sdp_query_vid_pid_callback, conn->addr,
+                        BLUETOOTH_SERVICE_CLASS_PNP_INFORMATION);
+                    printf("[BTSTACK_HOST] PnP SDP query for '%s': status=0x%02X\n",
+                           conn->name, sdp_rc);
+                }
+
                 // Check if this is a direct-L2CAP device by profile or name
                 bool is_direct_l2cap = (conn->profile &&
                                         conn->profile->classic == BT_CLASSIC_DIRECT_L2CAP);
@@ -6157,6 +6190,15 @@ bool btstack_classic_get_connection(uint8_t conn_index, btstack_classic_conn_inf
     info->is_ble = false;
 
     return true;
+}
+
+static uint8_t classic_link_count(void)
+{
+    uint8_t n = 0;
+    for (int i = 0; i < MAX_CLASSIC_CONNECTIONS; i++) {
+        if (classic_state.connections[i].active) n++;
+    }
+    return n;
 }
 
 // Get number of active connections (Classic + BLE)


### PR DESCRIPTION
# fix(bt): query PnP SDP on the hid_host path so DualSense binds correctly

## Problem

A DualSense that connects through **HID Host** is silently driven by the **DualShock 4** driver.

The link looks completely healthy — `hid_ready=1`, stable for minutes, no errors, no disconnects — but it produces **zero input events**. `router_submit_input()` is never called, so `add_player()` never fires and the pad registers no player. From the outside it looks like "connects but doesn't work", which is what sent me hunting through reconnection logic for a long time before finding the real cause.

## Root cause

The only `sdp_client_query_uuid16(..., BLUETOOTH_SERVICE_CLASS_PNP_INFORMATION)` call site sits behind:

```c
if (classic_state.pending_hid_connect && wiimote_conn.active) {
```

That is the direct-L2CAP path. A pad that comes up through HID Host is **never queried**, so `conn->product_id` stays `0`.

`REMOTE_NAME_REQUEST_COMPLETE` then does:

```c
const bt_device_profile_t* name_profile = bt_device_lookup_by_name(name);
if (name_profile->default_vid) {
    conn->vendor_id = name_profile->default_vid;          // 0x054C
    uint16_t pid = bt_device_wiimote_pid_from_name(name); // 0 for non-Wiimotes
    if (pid) { conn->product_id = pid; }                  // never taken
}
```

So the device ends up as `054C:0000`. Then in `ds5_match()`:

```c
if (vendor_id == 0x054C && (product_id == 0x0CE6 || product_id == 0x0DF2)) return true;  // pid is 0 -> no
if (device_name) {
    if (strstr(device_name, "DualSense")) return true;      // name is "Wireless Controller" -> no
    if (strstr(device_name, "PS5 Controller")) return true; // -> no
}
```

Both branches fail. Sony's actual advertised Bluetooth name for the DualSense is **"Wireless Controller"**, which the name fallback doesn't know about — and it can't simply be added, because the DualShock 4 uses the same name. Disambiguating genuinely requires the PID, which is exactly what goes missing.

`ds4_match()` is looser, matches, and claims the device. It then parses a report format the DS5 never sends.

## Evidence

Captured live from a Pico W bridging a DualSense (`054C:0CE6`):

```
C0 act=1 ready=1 cid=0xFFFF vid=054C pid=0CE6    direct-L2CAP: correct
C0 act=1 ready=1 cid=0x0002 vid=054C pid=0000    hid_host: PID lost
D0 ci=0 vid=054C pid=0000 drv='Sony DualShock 4' 'Wireless Controller'
```

The last line is the bug: a DualSense bound to the DualShock 4 driver.

## Fix

Fire the PnP query from `HID_SUBEVENT_CONNECTION_OPENED` when `product_id` is still unknown. SDP resolves `054C:0CE6`, and the **existing** `bthid_update_device_info()` path re-evaluates driver selection onto the correct driver — no new matching logic needed.

**This is not DualSense-specific.** Any Sony pad reporting "Wireless Controller" whose PID isn't already known takes the same path.

## Second change

Adjacent, and found while chasing the same symptom.

The idle-scan safety net gated on `btstack_classic_get_connection_count()`, which deliberately sums **Classic and BLE**:

```c
!classic_state.pending_valid &&
btstack_classic_get_connection_count() == 0) {
    btstack_host_start_scan();
```

A single unrelated BLE HID device in range holds that gate shut permanently. I hit this with an **NVIDIA SHIELD remote** sitting on the desk — the bridge auto-connects to it as a HOGP device, `b=1` forever, and since Classic auto-connect requires `classic_state.inquiry_active`, a bonded Classic pad can then **never** be rediscovered after powering off. Only clearing bonds and re-pairing recovers it.

Added `classic_link_count()` and gated on that. The combined counter keeps its existing meaning for the LED/status callers that want a total.

Happy to split this into its own PR if you'd prefer them separate.

## Testing

- Pico W, `bt2usb`, DualSense `054C:0CE6`
- Before: `drv='Sony DualShock 4'`, no input events, `playersCount` stays 0
- After: correct driver binds, input flows, player registers
- Verified over repeated power-cycle/reconnect cycles, and with the SHIELD remote present to exercise the second change
- `make bt2usb_pico_w` clean, no new warnings

## Notes

Possibly related to #195 (Flydigi Vader 4 Pro repeatedly disconnects — Classic connect teardown loops), which touches the same area, though I haven't confirmed a shared cause.

One thing I did **not** change: with `product_id == 0`, `ds4_match()` will still claim any `054C` device. Making it decline when the PID is unknown would turn a silent misbind into a loud failure, but that's a behaviour change for existing DS4 users so I left it alone.
