### PR TITLE
feat(24g): add 24g2usb app and nRF24L01+ SN30 2.4G receiver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,10 @@ jobs:
           - lodgenet2usb_pico2
           - lodgenet2n64_pico
           - lodgenet2gc_pico
+          - 24g2usb_pico2_w
+          - 24g2usb_pico_w
+          - 24g2usb_pico
+          - 24g2usb_pico2
 
     steps:
       - name: Checkout code with submodules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
+## [Unreleased]
+
+### Added
+
+#### 24g2usb
+- **First radio input source: 8BitDo SN30 2.4G wireless receiver over nRF24L01+.** New `24g2usb` app drives an nRF24L01+ over SPI, impersonating the SN30 2.4G's OEM USB dongle closely enough that controllers pair and cold-link directly — no 8BitDo dongle needed. The receiver runs off the radio's IRQ line and a hardware alarm rather than the main polling loop, so other core-0 work (flash writes, LED updates) can't stall a dwell and drop a packet. Supports exactly one controller by design — USB output only ever surfaces a single player (same limitation `bt2usb` already carries), and two controllers hopping the same table at independent phase can starve each other's dwell indefinitely. Hold BOOTSEL ~1.5s to pair a controller. Boards: Pico 2 W, Pico W, Pico, Pico 2. See [24g2usb](docs/apps/24g2usb.md), [24G input](docs/input/24g.md), and the [24G protocol reference](docs/protocols/24g.md) (recovered by logic-analyser capture of the OEM dongle's SPI bus).
+
+---
+
 ## [2.4.1] — 2026-08-16
 
 Patch release. **Every adapter running 2.4.0 should update**: the universal profile hotkeys added in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,7 +359,13 @@ Console protocols use RP2040 PIO for precise timing:
 4. Key functions:
    - `<protocol>_host_init()` - Initialize PIO/GPIO
    - `<protocol>_host_task()` - Poll controller, submit to router
-   - Use `router_submit_input()` with dev_addr 0xD0+ range
+   - Use `router_submit_input()` with a dev_addr in the 0xB0+ range. The
+     0xD0-0xFF space is already fully carved into 16-wide sub-ranges by
+     existing drivers (0xD0 GC/UART, 0xE0 N64/3DO/PSX/Jaguar, 0xF0
+     NES/SNES/LodgeNet/PCE/arcade/JVS), and 0xC0 (Wii) and 0xB0 (24G) are
+     also claimed — grep `_DEV_ADDR` and `0x[A-F]0` in
+     `src/native/host/*/*.h` and `*.c` for the current assignments before
+     picking a new one
 
 5. Remember to invert Y-axis if protocol uses non-HID convention
 

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ CONSOLE_gc2eth_feather := joypad_gc2eth_feather
 CONSOLE_wii2usb := joypad_wii2usb
 CONSOLE_wii2gc := joypad_wii2gc
 CONSOLE_wii2n64 := joypad_wii2n64
+CONSOLE_24g2usb := joypad_24g2usb
 CONSOLE_lodgenet2usb := joypad_lodgenet2usb
 CONSOLE_lodgenet2n64 := joypad_lodgenet2n64
 CONSOLE_lodgenet2gc := joypad_lodgenet2gc
@@ -227,6 +228,10 @@ APP_gc2usb_feather_usbhost := feather_usbhost gc2usb_feather_usbhost gc2usb_feat
 APP_wii2usb_kb2040 := kb2040 wii2usb wii2usb_kb2040 Wii USB
 APP_wii2gc_kb2040 := kb2040 wii2gc wii2gc_kb2040 Wii GameCube
 APP_wii2n64_pico := pico wii2n64 wii2n64_pico Wii N64
+APP_24g2usb_pico2_w := pico2_w 24g2usb 24g2usb_pico2_w 24G USB
+APP_24g2usb_pico_w := pico_w 24g2usb 24g2usb_pico_w 24G USB
+APP_24g2usb_pico := pico 24g2usb 24g2usb_pico 24G USB
+APP_24g2usb_pico2 := pico2 24g2usb 24g2usb_pico2 24G USB
 APP_lodgenet2usb_pico := pico lodgenet2usb lodgenet2usb_pico LodgeNet USB
 APP_lodgenet2usb_pico2 := pico2 lodgenet2usb lodgenet2usb_pico2 LodgeNet USB
 APP_lodgenet2n64_pico := pico lodgenet2n64 lodgenet2n64_pico LodgeNet N64
@@ -306,6 +311,10 @@ APPS += controller_fisherprice_v2_kb2040
 APPS += controller_alpakka_pico
 APPS += usb2ami_rp2040zero
 APPS += usb2ami_xiao
+APPS += 24g2usb_pico2_w
+APPS += 24g2usb_pico_w
+APPS += 24g2usb_pico
+APPS += 24g2usb_pico2
 APPS := $(strip $(APPS))
 
 # Stable apps for release
@@ -435,6 +444,10 @@ help:
 	@echo "  make pce2usb_pico_w     - PCEngine -> USB HID (Pico W)"
 	@echo "  make jag2usb_pico       - Atari Jaguar -> USB HID (Pico)"
 	@echo "  make jag2usb_pico_w     - Atari Jaguar -> USB HID (Pico W)"
+	@echo "  make 24g2usb_pico2_w     - SN30 2.4G -> USB HID (Pico 2 W)"
+	@echo "  make 24g2usb_pico_w      - SN30 2.4G -> USB HID (Pico W)"
+	@echo "  make 24g2usb_pico        - SN30 2.4G -> USB HID (Pico)"
+	@echo "  make 24g2usb_pico2       - SN30 2.4G -> USB HID (Pico 2)"
 	@echo "  make lodgenet2usb_pico   - LodgeNet -> USB HID (Pico)"
 	@echo "  make lodgenet2usb_pico2  - LodgeNet -> USB HID (Pico 2)"
 	@echo "  make lodgenet2n64_pico   - LodgeNet -> N64 (Pico)"
@@ -1304,6 +1317,22 @@ jag2usb_pico:
 jag2usb_pico_w:
 	$(call build_app,jag2usb_pico_w)
 
+.PHONY: 24g2usb_pico2_w
+24g2usb_pico2_w:
+	$(call build_app,24g2usb_pico2_w)
+
+.PHONY: 24g2usb_pico_w
+24g2usb_pico_w:
+	$(call build_app,24g2usb_pico_w)
+
+.PHONY: 24g2usb_pico
+24g2usb_pico:
+	$(call build_app,24g2usb_pico)
+
+.PHONY: 24g2usb_pico2
+24g2usb_pico2:
+	$(call build_app,24g2usb_pico2)
+
 .PHONY: lodgenet2usb_pico
 lodgenet2usb_pico:
 	$(call build_app,lodgenet2usb_pico)
@@ -1745,6 +1774,22 @@ flash-pce2usb_pico:
 .PHONY: flash-pce2usb_pico_w
 flash-pce2usb_pico_w:
 	@$(MAKE) --no-print-directory _flash_app APP_NAME=pce2usb_pico_w
+
+.PHONY: flash-24g2usb_pico2_w
+flash-24g2usb_pico2_w:
+	@$(MAKE) --no-print-directory _flash_app APP_NAME=24g2usb_pico2_w
+
+.PHONY: flash-24g2usb_pico_w
+flash-24g2usb_pico_w:
+	@$(MAKE) --no-print-directory _flash_app APP_NAME=24g2usb_pico_w
+
+.PHONY: flash-24g2usb_pico
+flash-24g2usb_pico:
+	@$(MAKE) --no-print-directory _flash_app APP_NAME=24g2usb_pico
+
+.PHONY: flash-24g2usb_pico2
+flash-24g2usb_pico2:
+	@$(MAKE) --no-print-directory _flash_app APP_NAME=24g2usb_pico2
 
 .PHONY: flash-lodgenet2usb_pico
 flash-lodgenet2usb_pico:

--- a/docs/apps/24g2usb.md
+++ b/docs/apps/24g2usb.md
@@ -1,0 +1,79 @@
+# 24g2usb
+
+8BitDo SN30 2.4G wireless receiver to USB HID gamepad.
+
+## Overview
+
+Drives an nRF24L01+ radio over SPI, impersonating the 8BitDo SN30 2.4G dongle closely enough that a SN30 2.4G controller pairs and links to it directly. The linked controller is presented to the host as a USB HID gamepad -- no 8BitDo dongle required. The receiver supports exactly one controller at a time; see "Single controller only" below for why.
+
+## Input
+
+[24G Input](../input/24g.md) -- interrupt-driven nRF24L01+ receiver decoding the SN30 2.4G wire protocol (64-channel frequency hopping, 13-byte frames). See [24G Protocol](../protocols/24g.md) for the full wire format.
+
+## Output
+
+[USB Device Output](../output/usb-device.md) -- USB HID gamepad with multiple emulation modes.
+
+## Wiring
+
+The nRF24L01+ module connects to `spi0`. CE and CSN are ordinary GPIOs driven by
+the driver, not SPI peripheral functions.
+
+| nRF24L01+ | Pico / Pico 2 (W) | Notes |
+|-----------|-------------------|-------|
+| VCC | 3V3 | Not 5V. Add a decoupling cap (10uF) across VCC/GND at the module -- these radios are notoriously sensitive to supply noise. |
+| GND | GND | |
+| CE | GPIO 4 | Plain GPIO |
+| CSN | GPIO 5 | Plain GPIO (chip select, driven manually) |
+| SCK | GPIO 6 | `spi0` SCK |
+| MOSI | GPIO 7 | `spi0` TX |
+| MISO | GPIO 0 | `spi0` RX |
+| IRQ | GPIO 8 | Required -- the receiver is interrupt-driven, not polled |
+
+GPIO 4 and GPIO 7 are not interchangeable: on RP2040/RP2350, GPIO 7 is the fixed
+`spi0` TX function and GPIO 4 is `spi0` RX, so MOSI must be on 7 and CE on 4.
+
+## Core Configuration
+
+| Setting | Value |
+|---------|-------|
+| Routing mode | SIMPLE (1:1) |
+| Player slots | 1 (fixed) |
+| SCK pin | GPIO 6 (spi0) |
+| MOSI pin | GPIO 7 (spi0) |
+| MISO pin | GPIO 0 (spi0) |
+| CSN pin | GPIO 5 |
+| CE pin | GPIO 4 |
+| IRQ pin | GPIO 8 |
+
+Pins are clear of GP23/24/25/29, which the CYW43 module claims on `_w` boards.
+
+## Key Features
+
+- **No dongle required** -- a SN30 2.4G controller pairs and links directly, cold-acquiring in under a second.
+- **Interrupt-driven radio** -- the receiver runs off the nRF24's IRQ line and a hardware alarm, not the main polling loop, so flash writes and other core-0 work can't stall a dwell and drop a packet.
+- **Pairing gesture** -- hold the BOOTSEL button ~1.5s to begin pairing. See [24G Input](../input/24g.md#pairing) for the full flow.
+- **LED indicator** -- reflects linked controller count (0 or 1) via `leds_set_connected_devices()`.
+- **USB output modes** -- SInput, XInput, PS3, PS4, Switch, Keyboard/Mouse (BOOTSEL double-click to cycle, triple-click to reset to HID).
+
+## Single controller only
+
+The receiver supports exactly one paired controller, matched by `MAX_PLAYER_SLOTS 1` and `USB_OUTPUT_PORTS 1`. USB output only ever surfaces player index 0 (`sinput_mode.c`, `hid_mode.c` and `xinput_mode.c` all `(void)player_index` and write to the single `ITF_NUM_HID_GAMEPAD` interface -- only `gc_adapter_mode.c` routes `player_index` to distinct USB interfaces, same limitation `bt2usb` carries), and two controllers hopping the same 64-channel table at independent phase could starve each other's dwell indefinitely if they powered on close in phase. Rather than ship a scheduler for a case USB couldn't deliver anyway, this app tracks a single controller. Pairing re-offers the same address and replaces whichever controller was previously paired to it.
+
+## Supported Boards
+
+| Board | Build Command |
+|-------|---------------|
+| Pico 2 W | `make 24g2usb_pico2_w` |
+| Pico W | `make 24g2usb_pico_w` |
+| Pico | `make 24g2usb_pico` |
+| Pico 2 | `make 24g2usb_pico2` |
+
+No CYW43 or BTstack needed -- these boards are used only for their onboard LED / form factor.
+
+## Build and Flash
+
+```bash
+make 24g2usb_pico2_w
+make flash-24g2usb_pico2_w
+```

--- a/docs/apps/index.md
+++ b/docs/apps/index.md
@@ -72,6 +72,7 @@ These apps read retro controllers directly and output as USB HID gamepads.
 | `nes2usb` | NES | SIMPLE | KB2040 | `make nes2usb_kb2040` |
 | `neogeo2usb` | Neo Geo | SIMPLE | KB2040 | `make neogeo2usb_kb2040` |
 | `lodgenet2usb` | LodgeNet | SIMPLE | Pico | `make lodgenet2usb_pico` |
+| `24g2usb` | 24G (SN30 2.4G) | SIMPLE | Pico 2 W/Pico W/Pico/Pico 2 | `make 24g2usb_pico2_w` |
 | `nuon2usb` | Nuon | SIMPLE | KB2040 | `make nuon2usb_kb2040` |
 | `psx2usb` | PSX/PS2 | SIMPLE | QT Py/KB2040/Pico | `make psx2usb_qtpy` (or `_kb2040` / `_pico`) |
 

--- a/docs/input/24g.md
+++ b/docs/input/24g.md
@@ -1,0 +1,101 @@
+# 24G Input Interface
+
+Receives a single 8BitDo SN30 2.4G wireless controller directly over an nRF24L01+ radio, impersonating the OEM USB dongle closely enough that the controller pairs and links without it.
+
+## Protocol
+
+An interrupt-driven nRF24L01+ receiver following a 64-channel frequency-hopping sequence, decoding 13-byte frames at up to ~99 packets/second per linked controller.
+
+See [24G Protocol](../protocols/24g.md) for the full wire format: radio configuration, the hop table, frame layout, and the pairing rendezvous.
+
+**Location**: `src/native/host/rf24g/`
+
+### Scheduling
+
+The radio runs off interrupts, not the main polling loop:
+
+- **IRQ (falling edge)** -- RX_DR. The ISR drains the RX FIFO, decodes the newest valid frame, waits an ACK guard window, retunes to the next hop index, and re-arms the dwell alarm.
+- **Hardware alarm** -- fires if a dwell expires with nothing received; advances the hop index and retunes anyway, counting a miss.
+
+This keeps packet capture immune to jitter from other core-0 work (LED updates, flash writes, USB polling) -- a main-loop-polled design would drop packets under load.
+
+### Link States
+
+`PARK` -> `SEARCH` -> `LINKED`, plus `PAIRING`:
+
+- **PARK** -- sits on the controller's only unlinked-probe channel (2447 MHz), rewriting `RF_CH` every ~2ms with CE held high, matching the OEM dongle's idle behavior.
+- **SEARCH** -- a 52-hop sweep, giving acquisition a second, independent path in alongside a direct probe contact.
+- **LINKED** -- every frame's hop-index byte re-syncs both index and phase, so the link self-heals after any stall.
+- **PAIRING** -- see [Pairing](#pairing) below.
+
+## Supported Controllers
+
+| Device | Detection |
+|--------|-----------|
+| 8BitDo SN30 2.4G wireless controller | Links via the SN30 2.4G RF protocol; no other controller in this family has been tested |
+
+## Button Mapping
+
+| SN30 2.4G | JP_BUTTON_* | Notes |
+|-----------|-------------|-------|
+| B | B1 | |
+| A | B2 | |
+| Y | B3 | |
+| X | B4 | |
+| L | L1 | |
+| R | R1 | |
+| Select | S1 | |
+| Start | S2 | Also the controller's power button |
+| D-pad Up | DU | Set by **either** `byte2:0x80` or `byte3:0x40` -- both fire together on hardware but are reported as a single button, never surfaced separately |
+| D-pad Down | DD | |
+| D-pad Left | DL | |
+| D-pad Right | DR | |
+
+Combinations (including diagonals) are a plain bitwise OR at the protocol level -- no SOCD handling needed.
+
+Layout reported as `LAYOUT_NINTENDO_4FACE` (SNES-style face buttons).
+
+## Analog Axes
+
+None -- the SN30 2.4G has no sticks or analog triggers. `analog[]` stays at the 128 center `init_input_event()` sets.
+
+## Connection Detection
+
+- A frame is only decoded for buttons once the controller is `LINKED` -- an unlinked (probing) controller sets `byte3:0x20` (Start) on most probe frames, which would otherwise appear as a phantom Start press.
+- `event.transport = INPUT_TRANSPORT_NATIVE`, so the router auto-registers the player on the first frame without waiting for a button press.
+- On link loss, the player at that device address is removed rather than left registered with stale state.
+
+## Pairing
+
+Hold the BOOTSEL button ~1.5s to begin pairing (see [24g2usb app](../apps/24g2usb.md)). The pairing exchange:
+
+1. Listens on the SN30 2.4G rendezvous address at 2447 MHz for the controller's request burst (`35 04 00 <counter>`).
+2. Waits for the burst to go quiet (~250ms), then replies ~346ms after the last request with the offered address and its complement.
+3. Runs 5 reply/listen cycles (25 replies at 20ms, then 500ms listening) -- the controller stops re-requesting once it accepts, only in the final cycle.
+4. The offered address is live the moment the exchange ends -- its pipe was already open (see [Addressing](#addressing) below) -- but the controller ceasing to ask isn't proof it actually took the address, so a follow-up watch checks whether a real frame arrives on it within the next several seconds and logs either `confirmed -- frames arriving` or `no frames yet`.
+
+   That confirmation is diagnostic only: there is nothing to roll back either way, unlike an earlier design where an unconfirmed claim reverted. **`no frames yet` does not mean pairing failed.** A controller that already held this address, or one that won't transmit until power-cycled, stays silent through the watch and still ends up paired -- it links on its next power-on. Re-pairing an already-paired controller trips this every time, because a controller sitting in pairing mode sends no data frames at all. If you see it, power-cycle the controller before assuming anything went wrong.
+
+ACK counts are not a reliable success signal during pairing -- the controller ceasing to request is.
+
+## Addressing
+
+The receiver's own identity (the 4-byte body of its address -- see [24G Protocol](../protocols/24g.md) for the address layout) is derived once at boot from the board's factory-programmed unique ID, not chosen, negotiated, or stored anywhere. Hashing the whole ID rather than a prefix matters because boards from the same production reel commonly share the leading bytes of that ID.
+
+Because the derivation is a pure function of the board, it comes out identical on every boot: there is nothing to persist to flash and nothing to lose on a power cycle. A controller paired to a given board stays paired across a reboot and across a reflash of the same board. Moving a controller to a *different* board changes the receiver ID -- a different unique ID hashes differently -- so it requires re-pairing, exactly as swapping in a different physical OEM dongle would.
+
+Only pipe 0 is open from boot (`EN_RXADDR = 0x01`); there is no "claimed" state gating reception, only whether the controller has actually been heard from yet (used for the `seen`/diagnostics reporting).
+
+The receiver supports exactly one paired controller at a time (see [24g2usb app](../apps/24g2usb.md#single-controller-only) for why). Pairing always re-offers the same address, so pairing a second controller replaces whichever controller was previously paired to it -- there is no way to hold two controllers' addresses simultaneously.
+
+## Configuration
+
+- **Pin defines** (`RF24G_PIN_*` in `rf24g_host.h`, `#ifndef`-guarded so an app can override): `RF24G_PIN_MISO`, `RF24G_PIN_CE`, `RF24G_PIN_CSN`, `RF24G_PIN_SCK`, `RF24G_PIN_MOSI`, `RF24G_PIN_IRQ`
+- **Device address**: `RF24G_DEV_ADDR` (`0xB0`)
+- **Transport type**: `INPUT_TRANSPORT_NATIVE`
+- **Input source**: `INPUT_SOURCE_NATIVE_24G`
+- **SPI**: hardware `spi0` at 8 MHz (the nRF24L01+ tolerates up to 10 MHz)
+
+## Apps Using This Input
+
+- [24g2usb](../apps/24g2usb.md) -- SN30 2.4G controller to USB HID gamepad

--- a/docs/protocols/24g.md
+++ b/docs/protocols/24g.md
@@ -1,0 +1,135 @@
+# 24G Protocol (SN30 2.4G)
+
+Wire protocol reference for the 8BitDo SN30 2.4G wireless controller and its nRF24L01+-based radio link. Recovered by logic-analyser capture of the SPI bus between the OEM receiver dongle's MCU and its radio chip (a Beken BK2425, an nRF24L01+ register-compatible clone), then confirmed live with a genuine nRF24L01+.
+
+**Location**: `src/native/host/rf24g/sn30_protocol.h`, `rf24g_host.c`
+
+## Radio Configuration
+
+| Register | Value | Meaning |
+|---|---|---|
+| `RF_SETUP` | `0x27` | 250 kbps, max PA |
+| `SETUP_AW` | `0x03` | 5-byte addresses |
+| `CONFIG` | `0x3F` | `PWR_UP`, `PRIM_RX`, `EN_CRC`+`CRCO` (16-bit CRC); RX_DR unmasked (the OEM dongle masks all IRQs and polls `STATUS` instead -- this driver uses the IRQ line) |
+| `EN_AA` | `0x3F` | auto-ACK, all pipes -- the controller is PTX and needs it |
+| `FEATURE` | **`0x06`** | dynamic payload + ack payload, **`EN_DYN_ACK` clear** -- see warning below |
+| `DYNPD` | `0x3F` | dynamic payload length, all pipes (payloads are 13 bytes, not the 32 `RX_PW_Pn` implies) |
+| `SETUP_RETR` | `0x12` | ARD 500us, 2 retries |
+| `RX_ADDR_P0` / `TX_ADDR` | `E4 81 00 EA B3` | OEM link address |
+| `RX_ADDR_P1` | `E4 17 D8 55 AA` | pairing rendezvous address |
+
+`ACTIVATE 0x50 0x73` must precede writing `FEATURE`/`DYNPD` -- they're locked otherwise.
+
+!!! warning "`FEATURE` must be `0x06`, not `0x07`"
+    The OEM dongle uses `FEATURE = 0x07` (`EN_DYN_ACK` set). Its BK2425 is an nRF24 clone that does not honor `EN_DYN_ACK` the same way a genuine nRF24L01+ does. On real nRF24 silicon, `0x07` causes the radio to refuse to ACK the controller's NO_ACK probe frames, and the controller then never starts hopping. Measured A/B, same controller, cold start each time: `0x07` -> 3 probes, 0 links, 0 of 74s linked; `0x06` -> 1 probe, 1 link, 47 of 51s linked, 1500 packets received. **Do not "correct" this to match the dongle.**
+
+## Frequency Hopping
+
+The link hops across **16 channels** on a **64-step sequence**. Byte 10 of every linked frame carries a counter (0-63) that, once linked, equals the current hop index -- so a receiver resynchronizes from any single received packet instead of searching blind.
+
+```c
+static const uint8_t hop_table[64] = {
+      6,  24,  47,  67,  11,  29,  51,  69,
+     14,  33,  55,  73,  17,  36,  59,  76,
+     76,  59,  36,  17,  73,  55,  33,  14,
+     69,  51,  29,  11,  67,  47,  24,   6,
+     67,  47,  24,   6,  69,  51,  29,  11,
+     73,  55,  33,  14,  76,  59,  36,  17,
+     17,  36,  59,  76,  14,  33,  55,  73,
+     11,  29,  51,  69,   6,  24,  47,  67,
+};
+```
+
+Idle/unpaired, the receiver parks on `RF_CH = 0x2F` (2447 MHz) -- itself hop-table indices 2, 29, 33 and 62, so a hopping controller is guaranteed to visit it periodically.
+
+!!! warning "`idx + 1` is the wrong successor -- three times in every 64 hops"
+    The index does not count up and wrap. It advances by one within a 16-index block, but the blocks run in a fixed non-ascending order: `32..47, 48..63, 16..31, 0..15, 32..47, ...`. So the transitions `63->16`, `15->32` and `31->0` are **not** `+1`. Treating it as a plain counter loses the boundary transitions, and because both ends then keep advancing by one from a wrong point, the resulting 16-index offset *persists* until the free-running channel coincidentally realigns -- it isn't a one-dwell cost. Use the block-aware successor:
+
+    ```c
+    static inline uint8_t sn30_next_idx(uint8_t idx)
+    {
+        static const uint8_t NEXT_BLK[4] = { 2, 0, 3, 1 };   /* 2 -> 3 -> 1 -> 0 */
+        idx &= 0x3F;
+        return ((idx & 0x0F) != 0x0F) ? (uint8_t)(idx + 1)
+                                      : (uint8_t)(NEXT_BLK[idx >> 4] << 4);
+    }
+    ```
+
+    Measured impact: naive `+1` sustains 61.6 pkt/s; the block-aware successor sustains 104.3 pkt/s against a controller transmitting ~99 frames/s -- a 1.69x difference, entirely from empty dwells caused by chasing the wrong channel after a boundary.
+
+## Link Acquisition
+
+| State | Behavior |
+|---|---|
+| **PARK** | Sits on 2447 MHz, CE held high, `RF_CH` rewritten every ~2ms. No periodic sweep timer -- sweeping would take the receiver off the only channel a cold controller uses. |
+| **SEARCH** | One 52-hop sweep -- a second, independent path to acquisition alongside a direct contact on the park channel. Sweeping and hopping traverse the same 16 channels, so a coincidence is bounded. |
+| **LINKED** | Every frame's hop-index byte resynchronizes index *and* phase, so the link self-heals after any stall without needing to reacquire from scratch. |
+
+A cold controller probes on 2447 MHz (and occasionally other hop channels while scanning) with the frame's hop-index byte pinned at 48 -- that value is a fixed probe marker, not a real hop index.
+
+!!! warning "Never validate a frame on `byte12 == 0x10`"
+    Every ordinary frame carries `0x10` in byte 12, but the initial contact frame that begins a link carries `0x31`. Requiring `0x10` silently discards exactly the frame that starts a link.
+
+!!! warning "Don't decode buttons from an unlinked (probing) frame"
+    Byte 3 bit `0x20` is Start -- also the controller's power button -- and it is set on most probe frames (the controller powers on holding Start). Decoding buttons before the link is established emits a phantom Start press on nearly every probe. Gate button decoding on `LINKED` state.
+
+## Frame Format (13 bytes)
+
+```
+80 0D 00 00 00 00 80 80 80 80 <idx> <cyc> 10    <- controller at rest
+ 0  1  2  3  4  5  6  7  8  9   10    11   12
+```
+
+| Byte | Meaning |
+|---|---|
+| 0 | `0x80` constant -- header |
+| 1 | `0x0D` constant -- length (13) |
+| 2 | buttons -- see below |
+| 3 | buttons -- see below |
+| 4-5 | unused, always `0x00` |
+| 6-9 | `0x80` constant -- no analog axes (SN30 2.4G has no sticks) |
+| 10 | hop index, `0x00`-`0x3F`, block-ordered (see above); pinned at `0x30` (48) on unlinked probes |
+| 11 | `<base> \| (counter >> 4)` -- low two bits are the frame counter's high bits; upper six bits are address-tied but not decoded (open question upstream) |
+| 12 | `0x10` on ordinary frames, `0x31` on the contact frame that begins a link |
+
+### Byte 2
+
+| Bit | Mask | Button |
+|---|---|---|
+| 7 | `0x80` | Up |
+| 6 | `0x40` | Down |
+| 5 | `0x20` | Left |
+| 4 | `0x10` | Right |
+| 3 | `0x08` | A |
+| 2 | `0x04` | B |
+| 1 | `0x02` | X |
+| 0 | `0x01` | Y |
+
+### Byte 3
+
+| Bit | Mask | Button |
+|---|---|---|
+| 6 | `0x40` | Up (fires together with byte 2 bit 7 -- treat as the same button, never surface separately) |
+| 5 | `0x20` | Start (also the power button) |
+| 4 | `0x10` | Select |
+| 3 | `0x08` | R |
+| 0 | `0x01` | L |
+
+Combinations, including all four diagonals, are a plain bitwise OR of the individual bits -- no SOCD handling exists at the protocol level.
+
+## Pairing Rendezvous
+
+`RX_ADDR_P1` (`E4 17 D8 55 AA`) is a dedicated pairing address, listened to at 2447 MHz only.
+
+1. **Request burst.** A controller entering pairing mode (held Select ~3-4s) transmits `35 04 00 <counter8>` repeatedly, about 24ms apart, then goes quiet and listens.
+2. **Reply timing.** The responder must wait for the request burst to go quiet (~250ms) and send its first reply **346ms after the last request** -- answering the first request talks over the rest of the burst while the controller is still deaf.
+3. **Reply payload**, 13 bytes: `35 0D 01 <address:5> <~address:5>` -- header, length, message-type-response, the offered 5-byte address, then that address bitwise-complemented as a check field. The tail **must be recomputed** per offered address, never copied from a captured example.
+4. **Five reply/listen cycles.** 25 replies at 20ms intervals, then 500ms listening on the rendezvous address, repeated 5 times (125 replies total). The listening phases are load-bearing: the controller may re-request once or twice before settling, and the *only* signal that it accepted is it ceasing to request -- and only in the final cycle.
+5. **Provisional claim.** The offered address should not be persisted until a frame actually arrives on it (an 8s acceptance window is a reasonable bound) -- three attempts in the original recovery reported "paired" from ACK counts alone and delivered zero frames.
+
+!!! warning "ACK counts mean nothing during pairing"
+    The run that successfully bound a controller got 0 of 125 replies acknowledged; the OEM dongle itself only gets ~10 of 125. Judge success by the controller ceasing to request, never by ACK count.
+
+## Attribution
+
+Protocol recovered by logic-analyser capture (SPI tap between the OEM receiver's MCU and its BK2425 radio), independently confirmed live with a genuine nRF24L01+. Full capture notes and reverse-engineering detail: [github.com/FatBeard/sf30-2.4g-protocol](https://github.com/FatBeard/sf30-2.4g-protocol).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
     - PSX/PS2: input/psx.md
     - GameCube: input/gamecube.md
     - LodgeNet: input/lodgenet.md
+    - 24G: input/24g.md
     - NES: input/nes.md
     - PCEngine: input/pcengine.md
     - Neo Geo: input/neogeo.md
@@ -104,6 +105,7 @@ nav:
       - pce2usb: apps/pce2usb.md
       - neogeo2usb: apps/neogeo2usb.md
       - lodgenet2usb: apps/lodgenet2usb.md
+      - 24g2usb: apps/24g2usb.md
       - wii2usb: apps/wii2usb.md
       - psx2usb: apps/psx2usb.md
     - Wii Adapters:
@@ -141,6 +143,7 @@ nav:
     - Nuon Polyface: protocols/NUON_POLYFACE.md
     - PC Engine: protocols/PCENGINE.md
     - LodgeNet: protocols/lodgenet.md
+    - 24G: protocols/24g.md
     - SInput HID: protocols/sinput.md
   - Features:
     - SNES Rumble: features/SNES_RUMBLE.md

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -352,6 +352,13 @@ set(LODGENET_HOST_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/native/host/lodgenet/lodgenet_host.c
 )
 
+# 24G host sources (nRF24L01+ radio, SN30 2.4G wireless dongle emulation)
+set(RF24G_HOST_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/native/host/rf24g/rf24g_host.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/native/host/rf24g/nrf24l01.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/native/host/rf24g/rf24g_hal_rp2040.c
+)
+
 # Wii extension host sources (hardware I2C via platform HAL + protocol lib)
 set(WII_HOST_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/native/host/wii_ext/wii_ext_host.c
@@ -2700,6 +2707,31 @@ elseif (PICO_BOARD STREQUAL "pico")
     target_compile_definitions(joypad_pce2usb PRIVATE BOARD_LED_PIN=25)
 endif()
 joypad_target_common(joypad_pce2usb)
+
+
+# --- 24G2USB (nRF24L01+ / SN30 2.4G wireless receiver -> USB HID) ---
+add_executable(joypad_24g2usb)
+target_compile_definitions(joypad_24g2usb PRIVATE CONFIG_24G2USB=1 CONFIG_USB=1 DISABLE_USB_HOST=1 USE_BOOTSEL_BUTTON=1)
+target_sources(joypad_24g2usb PUBLIC ${CORE_SOURCES} ${USB_DEVICE_SOURCES}
+    ${RF24G_HOST_SOURCES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/apps/24g2usb/app.c
+)
+target_include_directories(joypad_24g2usb PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/apps/24g2usb
+    ${CMAKE_CURRENT_SOURCE_DIR}/usb/usbd
+    ${CMAKE_CURRENT_SOURCE_DIR}/native/host/rf24g
+)
+target_link_libraries(joypad_24g2usb PRIVATE pico_stdlib pico_multicore hardware_pio hardware_spi pico_rand tinyusb_device tinyusb_board)
+# Status LED: Pico W / Pico 2 W's onboard LED is behind the CYW43 chip
+# (WL_GPIO0), so bring up cyw43_arch (no wireless) just to drive it. A plain
+# Pico / Pico 2's LED is a normal GPIO (GP25).
+if (PICO_BOARD STREQUAL "pico_w" OR PICO_BOARD STREQUAL "pico2_w")
+    target_compile_definitions(joypad_24g2usb PRIVATE BOARD_LED_CYW43=1)
+    target_link_libraries(joypad_24g2usb PRIVATE pico_cyw43_arch_none)
+elseif (PICO_BOARD STREQUAL "pico" OR PICO_BOARD STREQUAL "pico2")
+    target_compile_definitions(joypad_24g2usb PRIVATE BOARD_LED_PIN=25)
+endif()
+joypad_target_common(joypad_24g2usb)
 
 
 # --- JAG2USB (Atari Jaguar -> USB HID) ---

--- a/src/apps/24g2usb/app.c
+++ b/src/apps/24g2usb/app.c
@@ -1,0 +1,188 @@
+// app.c - 24G2USB App Entry Point
+// 8BitDo SN30 2.4G wireless receiver to USB HID gamepad adapter
+//
+// Drives an nRF24L01+ over SPI, impersonating the 8BitDo SN30 2.4G dongle
+// well enough that SN30 2.4G controllers pair and link to it, and routes
+// linked controllers to USB device output.
+
+#include "app.h"
+#include "core/router/router.h"
+#include "core/services/players/manager.h"
+#include "core/services/button/button.h"
+#include "core/input_interface.h"
+#include "core/output_interface.h"
+#include "usb/usbd/usbd.h"
+#include "rf24g_host.h"
+#include "core/services/leds/leds.h"
+#include "platform/platform.h"
+#include <stdio.h>
+
+#include "tusb.h"
+
+// ============================================================================
+// APP INPUT INTERFACES
+// ============================================================================
+
+static const InputInterface* input_interfaces[] = {
+    &rf24g_input_interface,
+};
+
+const InputInterface** app_get_input_interfaces(uint8_t* count)
+{
+    *count = sizeof(input_interfaces) / sizeof(input_interfaces[0]);
+    return input_interfaces;
+}
+
+// ============================================================================
+// APP OUTPUT INTERFACES
+// ============================================================================
+
+static const OutputInterface* output_interfaces[] = {
+    &usbd_output_interface,
+};
+
+const OutputInterface** app_get_output_interfaces(uint8_t* count)
+{
+    *count = sizeof(output_interfaces) / sizeof(output_interfaces[0]);
+    return output_interfaces;
+}
+
+// ============================================================================
+// BUTTON EVENT HANDLER (BOOTSEL)
+// ============================================================================
+//
+// Gesture map:
+//   DOUBLE_CLICK -> cycle USB output mode (SInput/XInput/PS3/PS4/Switch/KB-Mouse)
+//   TRIPLE_CLICK  -> reset to default HID mode
+//   HOLD (~1.5s)  -> begin radio pairing
+//
+// DOUBLE_CLICK/TRIPLE_CLICK are already the house convention for output-mode
+// switching (see pce2usb, bt2usb), so HOLD is the gesture left free for
+// pairing here -- it doesn't collide with either.
+
+static void on_button_event(button_event_t event)
+{
+    switch (event) {
+
+        case BUTTON_EVENT_DOUBLE_CLICK: {
+            usb_output_mode_t next = usbd_get_next_mode();
+            printf("[app:24g2usb] Double-click - switching USB mode -> %s\n",
+                   usbd_get_mode_name(next));
+            usbd_set_mode(next);
+            break;
+        }
+
+        case BUTTON_EVENT_TRIPLE_CLICK:
+            printf("[app:24g2usb] Triple-click - resetting to HID mode...\n");
+            if (!usbd_reset_to_hid()) {
+                printf("[app:24g2usb] Already in HID mode\n");
+            }
+            break;
+
+        case BUTTON_EVENT_HOLD: {
+            // The receiver's address is permanent and its pipe is always
+            // open (see rf24g_host.c's apply_pipe_addresses()), so
+            // re-offering it is always a legitimate re-pair (a replacement
+            // controller, or the same one after a factory reset), not an
+            // error -- including when the controller currently linked is
+            // the one being re-paired.
+            if (rf24g_host_is_pairing()) {
+                printf("[app:24g2usb] Hold - pairing already in progress\n");
+                break;
+            }
+            printf("[app:24g2usb] Hold - starting pairing...\n");
+            rf24g_host_begin_pairing();
+            break;
+        }
+
+        default:
+            break;
+    }
+}
+
+// ============================================================================
+// APP INITIALIZATION
+// ============================================================================
+
+void app_init(void)
+{
+    printf("[app:24g2usb] Initializing 24G2USB v%s\n", JOYPAD_VERSION);
+
+    button_init();
+    button_set_callback(on_button_event);
+
+    rf24g_host_init_pins(RF24G_PIN_SCK, RF24G_PIN_MOSI, RF24G_PIN_MISO,
+                         RF24G_PIN_CSN, RF24G_PIN_CE, RF24G_PIN_IRQ);
+
+    router_config_t router_cfg = {
+        .mode = ROUTING_MODE,
+        .merge_mode = MERGE_MODE,
+        .max_players_per_output = {
+            [OUTPUT_TARGET_USB_DEVICE] = USB_OUTPUT_PORTS,
+        },
+        .merge_all_inputs = false,
+        .transform_flags = TRANSFORM_NONE,
+    };
+    router_init(&router_cfg);
+
+    router_add_route(INPUT_SOURCE_NATIVE_24G, OUTPUT_TARGET_USB_DEVICE, 0);
+
+    player_config_t player_cfg = {
+        .slot_mode = PLAYER_SLOT_MODE,
+        .max_slots = MAX_PLAYER_SLOTS,
+        .auto_assign_on_press = AUTO_ASSIGN_ON_PRESS,
+    };
+    players_init_with_config(&player_cfg);
+
+    printf("[app:24g2usb] Initialization complete\n");
+    printf("[app:24g2usb]   Routing: SN30 2.4G -> USB HID Gamepad\n");
+    printf("[app:24g2usb]   Pins: SCK=%d MOSI=%d MISO=%d CSN=%d CE=%d IRQ=%d\n",
+           RF24G_PIN_SCK, RF24G_PIN_MOSI, RF24G_PIN_MISO,
+           RF24G_PIN_CSN, RF24G_PIN_CE, RF24G_PIN_IRQ);
+    printf("[app:24g2usb]   Hold BOOTSEL ~1.5s to pair a new controller\n");
+}
+
+// ============================================================================
+// APP TASK
+// ============================================================================
+
+void app_task(void)
+{
+    button_task();
+
+    // Update LED color when USB output mode changes
+    static usb_output_mode_t last_led_mode = USB_OUTPUT_MODE_COUNT;
+    usb_output_mode_t mode = usbd_get_mode();
+    if (mode != last_led_mode) {
+        uint8_t r, g, b;
+        usbd_get_mode_color(mode, &r, &g, &b);
+        leds_set_color(r, g, b);
+        last_led_mode = mode;
+    }
+
+    uint8_t linked = rf24g_host_get_device_count();
+    leds_set_connected_devices(linked);
+
+#ifdef RF24G_STATS_VERBOSE
+    // Periodic radio diagnostics on UART/CDC: packets/sec, measured frame
+    // period and an inter-arrival histogram. Opt-in only -- this app has no
+    // pico_enable_stdio_usb, so printf goes to UART0 and blocks the caller
+    // (uart_putc spins on a full TX FIFO) whether or not anything is
+    // listening on GP0/GP1. At ~190 chars/line this line-per-second call
+    // costs ~16ms of main-loop stall EVERY second whenever anything is
+    // linked, which is itself enough to cost a dwell -- exactly what this
+    // driver's interrupt-driven design exists to avoid elsewhere. Define
+    // RF24G_STATS_VERBOSE to get it back for measuring `pps`/`period`/
+    // `misses`. Once per second matches the 1s window pps is accumulated
+    // over, and it stays quiet while nothing is linked so an idle adapter
+    // doesn't spam the console.
+    if (linked > 0 || rf24g_host_is_pairing()) {
+        static uint32_t last_stats_ms = 0;
+        uint32_t now_ms = platform_time_ms();
+        if ((uint32_t)(now_ms - last_stats_ms) >= 1000) {
+            last_stats_ms = now_ms;
+            rf24g_host_print_stats();
+        }
+    }
+#endif
+}

--- a/src/apps/24g2usb/app.h
+++ b/src/apps/24g2usb/app.h
@@ -1,0 +1,83 @@
+// app.h - 24G2USB App Manifest
+// 8BitDo SN30 2.4G wireless receiver to USB HID gamepad adapter
+//
+// Drives an nRF24L01+ over SPI, impersonating the 8BitDo SN30 2.4G dongle well
+// enough that SN30 2.4G controllers pair and link to it, and presents them to
+// the host as a USB gamepad via the existing router -> usbd path.
+//
+// This manifest is a human-readable summary of what this app uses.
+// It is NOT consumed by the build system. The authoritative per-target
+// configuration lives in src/CMakeLists.txt. Only #ifndef-guarded flags are
+// read by code (see RF24G_PIN_* in native/host/rf24g/rf24g_host.h);
+// every other flag here is descriptive only and changing it has no effect.
+// See issue #198.
+
+#ifndef APP_24G2USB_H
+#define APP_24G2USB_H
+
+// ============================================================================
+// APP METADATA
+// ============================================================================
+#define APP_NAME "24G2USB"
+#define APP_DESCRIPTION "8BitDo SN30 2.4G wireless receiver to USB HID gamepad adapter"
+#define APP_AUTHOR "FatBeard"
+
+// ============================================================================
+// CORE DEPENDENCIES
+// ============================================================================
+
+// Input drivers
+#define REQUIRE_NATIVE_24G_HOST 1
+
+// Output drivers
+#define REQUIRE_USB_DEVICE 1
+#define USB_OUTPUT_PORTS 1              // Single gamepad for now. SInput/HID/XInput
+                                        // modes all (void)player_index and write to
+                                        // the single ITF_NUM_HID_GAMEPAD interface
+                                        // (see usb/usbd/modes/sinput_mode.c:402) --
+                                        // only gc_adapter_mode routes player_index to
+                                        // distinct ports. Same situation as bt2usb.
+
+// Services
+#define REQUIRE_PLAYER_MANAGEMENT 1
+
+// ============================================================================
+// PIN CONFIGURATION
+// ============================================================================
+// nRF24L01+ over spi0 (SCK GP6 / TX GP7 / RX GP0). Clear of GP23/24/25/29,
+// which the CYW43 module claims on _w boards.
+#define RF24G_PIN_MISO 0   // spi0 RX
+#define RF24G_PIN_CE   4
+#define RF24G_PIN_CSN  5
+#define RF24G_PIN_SCK  6   // spi0 SCK
+#define RF24G_PIN_MOSI 7   // spi0 TX
+#define RF24G_PIN_IRQ  8
+
+// ============================================================================
+// ROUTING CONFIGURATION
+// ============================================================================
+#define ROUTING_MODE ROUTING_MODE_SIMPLE
+#define MERGE_MODE MERGE_ALL
+
+// ============================================================================
+// PLAYER MANAGEMENT
+// ============================================================================
+#define PLAYER_SLOT_MODE PLAYER_SLOT_FIXED
+#define MAX_PLAYER_SLOTS 1               // The receiver supports exactly
+                                        // one controller, see rf24g_host.h
+#define AUTO_ASSIGN_ON_PRESS 1
+
+// ============================================================================
+// HARDWARE CONFIGURATION
+// ============================================================================
+#define BOARD "pico2_w"
+#define CPU_OVERCLOCK_KHZ 0
+#define UART_DEBUG 1
+
+// ============================================================================
+// APP INTERFACE
+// ============================================================================
+void app_init(void);
+void app_task(void);
+
+#endif // APP_24G2USB_H

--- a/src/apps/24g2usb/app.h
+++ b/src/apps/24g2usb/app.h
@@ -31,12 +31,9 @@
 
 // Output drivers
 #define REQUIRE_USB_DEVICE 1
-#define USB_OUTPUT_PORTS 1              // Single gamepad for now. SInput/HID/XInput
-                                        // modes all (void)player_index and write to
-                                        // the single ITF_NUM_HID_GAMEPAD interface
-                                        // (see usb/usbd/modes/sinput_mode.c:402) --
-                                        // only gc_adapter_mode routes player_index to
-                                        // distinct ports. Same situation as bt2usb.
+#define USB_OUTPUT_PORTS 1              // SInput/HID/XInput modes all write to a
+                                        // single HID interface regardless of
+                                        // player_index -- same as bt2usb.
 
 // Services
 #define REQUIRE_PLAYER_MANAGEMENT 1

--- a/src/apps/24g2usb/app_config.h
+++ b/src/apps/24g2usb/app_config.h
@@ -1,0 +1,65 @@
+/*
+ * 24G2USB LED Configuration
+ * Defines player LED colors and patterns for controllers
+ */
+
+#ifndef CONSOLE_LED_CONFIG_H
+#define CONSOLE_LED_CONFIG_H
+
+// Player 1 - Purple (SN30 2.4G theme)
+#define LED_P1_R 40
+#define LED_P1_G 0
+#define LED_P1_B 60
+#define LED_P1_PATTERN 0b00100
+
+// Player 2 - Blue
+#define LED_P2_R 0
+#define LED_P2_G 0
+#define LED_P2_B 64
+#define LED_P2_PATTERN 0b01010
+
+// Player 3 - Red
+#define LED_P3_R 64
+#define LED_P3_G 0
+#define LED_P3_B 0
+#define LED_P3_PATTERN 0b10101
+
+// Player 4 - Green
+#define LED_P4_R 0
+#define LED_P4_G 64
+#define LED_P4_B 0
+#define LED_P4_PATTERN 0b11011
+
+// Player 5 - Yellow
+#define LED_P5_R 64
+#define LED_P5_G 64
+#define LED_P5_B 0
+#define LED_P5_PATTERN 0b11111
+
+// Player 6 - Cyan
+#define LED_P6_R 0
+#define LED_P6_G 64
+#define LED_P6_B 64
+#define LED_P6_PATTERN 0b00011
+
+// Player 7 - Orange
+#define LED_P7_R 64
+#define LED_P7_G 32
+#define LED_P7_B 0
+#define LED_P7_PATTERN 0b00110
+
+// Default/Unassigned - White
+#define LED_DEFAULT_R 32
+#define LED_DEFAULT_G 32
+#define LED_DEFAULT_B 32
+#define LED_DEFAULT_PATTERN 0
+
+// Neopixel (WS2812) board LED patterns by player count
+#define NEOPIXEL_PATTERN_0 pattern_purples
+#define NEOPIXEL_PATTERN_1 pattern_purple
+#define NEOPIXEL_PATTERN_2 pattern_br
+#define NEOPIXEL_PATTERN_3 pattern_brg
+#define NEOPIXEL_PATTERN_4 pattern_brgp
+#define NEOPIXEL_PATTERN_5 pattern_brgpy
+
+#endif // CONSOLE_LED_CONFIG_H

--- a/src/core/app_registry.c
+++ b/src/core/app_registry.c
@@ -47,6 +47,9 @@ const char* app_registry_input_source_name(input_source_t source)
         case INPUT_SOURCE_NATIVE_NUON:     return "native_nuon";
         case INPUT_SOURCE_NATIVE_WII:      return "native_wii";
         case INPUT_SOURCE_NATIVE_PSX:      return "native_psx";
+        case INPUT_SOURCE_NATIVE_PCE:      return "native_pce";
+        case INPUT_SOURCE_NATIVE_JAGUAR:   return "native_jaguar";
+        case INPUT_SOURCE_NATIVE_24G:      return "native_24g";
         case INPUT_SOURCE_GPIO:            return "gpio";
         case INPUT_SOURCE_SENSORS:         return "sensors";
         case INPUT_SOURCE_I2C_PEER:        return "i2c_peer";

--- a/src/core/router/router.h
+++ b/src/core/router/router.h
@@ -49,6 +49,7 @@ typedef enum {
     INPUT_SOURCE_NATIVE_PSX,        // PS1/PS2 controller (bit-bang SIO)
     INPUT_SOURCE_NATIVE_PCE,        // PCEngine/TG-16 controller (bit-bang mux)
     INPUT_SOURCE_NATIVE_JAGUAR,     // Atari Jaguar controller (bit-bang matrix)
+    INPUT_SOURCE_NATIVE_24G,        // nRF24L01+ / SN30 2.4G wireless receiver
     INPUT_SOURCE_GPIO,
     INPUT_SOURCE_SENSORS,
     INPUT_SOURCE_I2C_PEER,

--- a/src/native/host/rf24g/nrf24l01.c
+++ b/src/native/host/rf24g/nrf24l01.c
@@ -1,0 +1,169 @@
+// nrf24l01.c - see nrf24l01.h for the API rationale.
+//
+// Every SPI transaction is [command byte][data...], clocked out over
+// rf24g_hal_spi_xfer() with CSN framing handled by the HAL. The first byte
+// clocked back on ANY command is STATUS -- nrf24_xfer() below returns it
+// unconditionally so callers that need it (nrf24_r_rx_payload(), for the
+// pipe number) don't need a separate NOP.
+//
+// Flash-safety: every function in this file is reachable from
+// rf24g_host.c's radio ISR / dwell-alarm chain (register writes/reads
+// happen throughout receive and retune), so every function here carries
+// __not_in_flash_func -- not just the ones the ISR calls directly, since
+// the attribute places only a function's own code in RAM, not its callees'.
+// This is defense in depth, not fault avoidance -- see rf24g_host.c's file
+// header for the full rationale.
+
+#include "nrf24l01.h"
+#include "rf24g_hal.h"
+#include <string.h>   // memcmp, in nrf24_probe() only (core 0, never the ISR)
+
+static uint8_t __not_in_flash_func(nrf24_xfer)(uint8_t cmd, const uint8_t* tx,
+                                                uint8_t* rx, uint8_t len)
+{
+    uint8_t txbuf[NRF24_MAX_PAYLOAD + 1];
+    uint8_t rxbuf[NRF24_MAX_PAYLOAD + 1];
+
+    // Byte loops rather than memcpy/memset, and the destination pointers are
+    // `volatile`-qualified -- NOT just plain byte loops. `len` is a runtime
+    // value, so a naive "for (i) buf[i] = x[i]" reads like it must compile to
+    // per-byte load/store pairs, but it doesn't: GCC's loop-idiom
+    // recognition (-ftree-loop-distribute-patterns, on by default from -O2)
+    // pattern-matches exactly that shape and silently rewrites it back into a
+    // real call to __wrap_memcpy/__wrap_memset -- confirmed by disassembly,
+    // reachable from the radio ISR. Qualifying the write side as `volatile`
+    // defeats the idiom-recognition pass: a volatile store is an observable
+    // side effect the compiler is not allowed to express as a bulk
+    // memcpy/memset call, or to reorder/merge with its neighbours. At
+    // len <= 32 the loop costs nothing worth measuring either way.
+    //
+    // If this function is touched again: re-verify with disassembly on BOTH
+    // `pico` (RP2040/Cortex-M0+) and `pico2` (RP2350) builds -- the two
+    // architectures' loop-idiom recognition thresholds differ, and a fixed
+    // trip count is not immune (see sn30_protocol.h's sn30_identity()).
+    volatile uint8_t *t = txbuf;
+    t[0] = cmd;
+    for (uint8_t i = 0; i < len; i++)
+        t[1 + i] = tx ? tx[i] : 0xFF;   // 0xFF = dummy clock bytes for a read
+
+    rf24g_hal_spi_xfer(txbuf, rxbuf, (size_t)len + 1);
+
+    if (rx) {
+        volatile uint8_t *r = rx;
+        for (uint8_t i = 0; i < len; i++) r[i] = rxbuf[1 + i];
+    }
+    return rxbuf[0];   // STATUS, clocked out with the command byte itself
+}
+
+void __not_in_flash_func(nrf24_write_reg)(uint8_t reg, uint8_t val)
+{
+    nrf24_xfer((uint8_t)(NRF24_CMD_W_REGISTER | (reg & 0x1F)), &val, NULL, 1);
+}
+
+uint8_t __not_in_flash_func(nrf24_read_reg)(uint8_t reg)
+{
+    uint8_t val = 0;
+    nrf24_xfer((uint8_t)(NRF24_CMD_R_REGISTER | (reg & 0x1F)), NULL, &val, 1);
+    return val;
+}
+
+void __not_in_flash_func(nrf24_write_reg_buf)(uint8_t reg, const uint8_t* buf, uint8_t len)
+{
+    nrf24_xfer((uint8_t)(NRF24_CMD_W_REGISTER | (reg & 0x1F)), buf, NULL, len);
+}
+
+void __not_in_flash_func(nrf24_read_reg_buf)(uint8_t reg, uint8_t* buf, uint8_t len)
+{
+    nrf24_xfer((uint8_t)(NRF24_CMD_R_REGISTER | (reg & 0x1F)), NULL, buf, len);
+}
+
+uint8_t __not_in_flash_func(nrf24_nop)(void)
+{
+    return nrf24_xfer(NRF24_CMD_NOP, NULL, NULL, 0);
+}
+
+uint8_t __not_in_flash_func(nrf24_fifo_status)(void)
+{
+    return nrf24_read_reg(NRF24_REG_FIFO_STATUS);
+}
+
+void __not_in_flash_func(nrf24_flush_rx)(void)
+{
+    nrf24_xfer(NRF24_CMD_FLUSH_RX, NULL, NULL, 0);
+}
+
+void __not_in_flash_func(nrf24_flush_tx)(void)
+{
+    nrf24_xfer(NRF24_CMD_FLUSH_TX, NULL, NULL, 0);
+}
+
+uint8_t __not_in_flash_func(nrf24_r_rx_pl_wid)(void)
+{
+    uint8_t w = 0;
+    nrf24_xfer(NRF24_CMD_R_RX_PL_WID, NULL, &w, 1);
+    return w;
+}
+
+uint8_t __not_in_flash_func(nrf24_r_rx_payload)(uint8_t* buf, uint8_t len)
+{
+    return nrf24_xfer(NRF24_CMD_R_RX_PAYLOAD, NULL, buf, len);
+}
+
+void __not_in_flash_func(nrf24_w_tx_payload)(const uint8_t* buf, uint8_t len)
+{
+    nrf24_xfer(NRF24_CMD_W_TX_PAYLOAD, buf, NULL, len);
+}
+
+void __not_in_flash_func(nrf24_activate)(void)
+{
+    uint8_t code = 0x73;
+    nrf24_xfer(NRF24_CMD_ACTIVATE, &code, NULL, 1);
+}
+
+void __not_in_flash_func(nrf24_set_channel)(uint8_t ch)
+{
+    nrf24_write_reg(NRF24_REG_RF_CH, ch);
+}
+
+void __not_in_flash_func(nrf24_power_up_rx)(void)
+{
+    // CONFIG 0x3F: PWR_UP + PRIM_RX + 16-bit CRC, with RX_DR left UNMASKED.
+    // The OEM dongle uses 0x7F (everything masked) because it polls STATUS
+    // in a tight loop instead of using the IRQ line at all. This driver is
+    // interrupt-driven (rf24g_host.c), so RX_DR has to actually reach the
+    // IRQ pin. TX_DS/MAX_RT stay masked; nothing here watches them while
+    // receiving.
+    nrf24_write_reg(NRF24_REG_CONFIG,
+                     (uint8_t)(NRF24_CONFIG_MASK_TX_DS | NRF24_CONFIG_MASK_MAX_RT |
+                               NRF24_CONFIG_EN_CRC | NRF24_CONFIG_CRCO |
+                               NRF24_CONFIG_PWR_UP | NRF24_CONFIG_PRIM_RX));
+}
+
+void __not_in_flash_func(nrf24_power_up_tx)(void)
+{
+    // CONFIG 0x7E: PTX, everything masked -- matches the dongle's own
+    // pairing-reply CONFIG write. The pairing state machine polls its own
+    // timing deadlines rather than TX_DS/MAX_RT -- see rf24g_host.c's
+    // pairing_send_reply().
+    nrf24_write_reg(NRF24_REG_CONFIG,
+                     (uint8_t)(NRF24_CONFIG_MASK_RX_DR | NRF24_CONFIG_MASK_TX_DS |
+                               NRF24_CONFIG_MASK_MAX_RT | NRF24_CONFIG_EN_CRC |
+                               NRF24_CONFIG_CRCO | NRF24_CONFIG_PWR_UP));
+}
+
+void __not_in_flash_func(nrf24_power_down)(void)
+{
+    nrf24_write_reg(NRF24_REG_CONFIG,
+                     (uint8_t)(NRF24_CONFIG_EN_CRC | NRF24_CONFIG_CRCO));
+}
+
+bool nrf24_probe(void)
+{
+    static const uint8_t pattern[NRF24_ADDR_LEN] = { 0xC2, 0xC2, 0xC2, 0xC2, 0xC2 };
+    uint8_t readback[NRF24_ADDR_LEN] = { 0 };
+
+    nrf24_write_reg_buf(NRF24_REG_RX_ADDR_P1, pattern, NRF24_ADDR_LEN);
+    nrf24_read_reg_buf(NRF24_REG_RX_ADDR_P1, readback, NRF24_ADDR_LEN);
+
+    return memcmp(pattern, readback, NRF24_ADDR_LEN) == 0;
+}

--- a/src/native/host/rf24g/nrf24l01.h
+++ b/src/native/host/rf24g/nrf24l01.h
@@ -1,0 +1,132 @@
+// nrf24l01.h - nRF24L01+ register/command driver
+//
+// Thin register- and command-level access, modelled on
+// src/apps/gc2eth_feather/w5500.c's shape (a handful of xfer/read/write
+// primitives, no protocol knowledge). All hardware access goes through
+// rf24g_hal.h -- this file has no pico-sdk (or other platform SDK)
+// dependency, so it works unchanged on any HAL implementation.
+//
+// Register map and command set: nRF24L01+ datasheet. This chip family also
+// covers the BK2425 clone used by the OEM 8BitDo dongle for register-dump
+// comparison purposes, and the ACTIVATE unlock command some clones require
+// to make FEATURE/DYNPD writable -- see nrf24_activate() and rf24g_host.c's
+// FEATURE=0x06 comment.
+
+#ifndef NRF24L01_H
+#define NRF24L01_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+// ---- Register map -------------------------------------------------------
+#define NRF24_REG_CONFIG       0x00
+#define NRF24_REG_EN_AA        0x01
+#define NRF24_REG_EN_RXADDR    0x02
+#define NRF24_REG_SETUP_AW     0x03
+#define NRF24_REG_SETUP_RETR   0x04
+#define NRF24_REG_RF_CH        0x05
+#define NRF24_REG_RF_SETUP     0x06
+#define NRF24_REG_STATUS       0x07
+#define NRF24_REG_OBSERVE_TX   0x08
+#define NRF24_REG_RPD          0x09
+#define NRF24_REG_RX_ADDR_P0   0x0A   // 5 bytes
+#define NRF24_REG_RX_ADDR_P1   0x0B   // 5 bytes
+#define NRF24_REG_RX_ADDR_P2   0x0C   // 1 byte -- shares P1's upper 4 bytes
+#define NRF24_REG_RX_ADDR_P3   0x0D   // 1 byte -- shares P1's upper 4 bytes
+#define NRF24_REG_RX_ADDR_P4   0x0E   // 1 byte -- shares P1's upper 4 bytes
+#define NRF24_REG_RX_ADDR_P5   0x0F   // 1 byte -- shares P1's upper 4 bytes
+#define NRF24_REG_TX_ADDR      0x10   // 5 bytes
+#define NRF24_REG_RX_PW_P0     0x11   // RX_PW_P1..P5 follow at +1 each
+#define NRF24_REG_FIFO_STATUS  0x17
+#define NRF24_REG_DYNPD        0x1C
+#define NRF24_REG_FEATURE      0x1D
+
+// CONFIG bits
+#define NRF24_CONFIG_MASK_RX_DR  0x40
+#define NRF24_CONFIG_MASK_TX_DS  0x20
+#define NRF24_CONFIG_MASK_MAX_RT 0x10
+#define NRF24_CONFIG_EN_CRC      0x08
+#define NRF24_CONFIG_CRCO        0x04
+#define NRF24_CONFIG_PWR_UP      0x02
+#define NRF24_CONFIG_PRIM_RX     0x01
+
+// STATUS bits
+#define NRF24_STATUS_RX_DR         0x40
+#define NRF24_STATUS_TX_DS         0x20
+#define NRF24_STATUS_MAX_RT        0x10
+#define NRF24_STATUS_RX_P_NO_MASK  0x0E
+#define NRF24_STATUS_RX_P_NO_SHIFT 1
+#define NRF24_STATUS_TX_FULL       0x01
+
+// FIFO_STATUS bits
+#define NRF24_FIFO_RX_EMPTY  0x01
+#define NRF24_FIFO_TX_EMPTY  0x10
+
+// FEATURE bits
+#define NRF24_FEATURE_EN_DPL     0x04
+#define NRF24_FEATURE_EN_ACK_PAY 0x02
+#define NRF24_FEATURE_EN_DYN_ACK 0x01   // do NOT set this -- see rf24g_host.c
+
+// ---- SPI command set ------------------------------------------------------
+#define NRF24_CMD_R_REGISTER    0x00   // | reg (5 bit)
+#define NRF24_CMD_W_REGISTER    0x20   // | reg (5 bit)
+#define NRF24_CMD_R_RX_PAYLOAD  0x61
+#define NRF24_CMD_W_TX_PAYLOAD  0xA0
+#define NRF24_CMD_FLUSH_TX      0xE1
+#define NRF24_CMD_FLUSH_RX      0xE2
+#define NRF24_CMD_REUSE_TX_PL   0xE3
+#define NRF24_CMD_R_RX_PL_WID   0x60
+#define NRF24_CMD_ACTIVATE      0x50
+#define NRF24_CMD_NOP           0xFF
+
+#define NRF24_ADDR_LEN     5
+#define NRF24_MAX_PAYLOAD 32
+
+// ---- Register access ------------------------------------------------------
+void    nrf24_write_reg(uint8_t reg, uint8_t val);
+uint8_t nrf24_read_reg(uint8_t reg);
+void    nrf24_write_reg_buf(uint8_t reg, const uint8_t* buf, uint8_t len);
+void    nrf24_read_reg_buf(uint8_t reg, uint8_t* buf, uint8_t len);
+
+// Clock a NOP -- the cheapest way to read STATUS (every command's first
+// clocked-out byte is STATUS; NOP just doesn't do anything else).
+uint8_t nrf24_nop(void);
+uint8_t nrf24_fifo_status(void);
+
+void    nrf24_flush_rx(void);
+void    nrf24_flush_tx(void);
+
+// Dynamic-payload width of the packet on top of the RX FIFO (R_RX_PL_WID).
+// Returns 0 if the FIFO is empty; a corrupt read can return >32, which the
+// datasheet's errata says to treat as "flush and discard".
+uint8_t nrf24_r_rx_pl_wid(void);
+
+// Pop `len` bytes off the RX FIFO. Returns STATUS as it stood on entry --
+// bits 3:1 (NRF24_STATUS_RX_P_NO_MASK) name the pipe this payload arrived
+// on, captured before the FIFO pop completes.
+uint8_t nrf24_r_rx_payload(uint8_t* buf, uint8_t len);
+
+void    nrf24_w_tx_payload(const uint8_t* buf, uint8_t len);
+
+// ACTIVATE 0x50 0x73 -- unlocks FEATURE/DYNPD on chip families that ship
+// them write-protected until toggled once. Harmless on a real nRF24L01+,
+// where FEATURE/DYNPD are always writable; required on some clones.
+void    nrf24_activate(void);
+
+void    nrf24_set_channel(uint8_t ch);
+
+// CONFIG transitions. PRX (power_up_rx) is the normal listening mode; PTX
+// (power_up_tx) is only entered for the pairing rendezvous reply burst, see
+// rf24g_host.c's pairing state machine.
+void    nrf24_power_up_rx(void);
+void    nrf24_power_up_tx(void);
+void    nrf24_power_down(void);
+
+// Presence check: writes a scratch pattern to RX_ADDR_P1 (5 bytes, cheap to
+// clobber -- every caller rewrites every pipe address before listening
+// anyway) and reads it back. There is no VERSIONR-equivalent register on
+// this chip family to check against a known value, unlike w5500_init()'s
+// VERSIONR read.
+bool    nrf24_probe(void);
+
+#endif // NRF24L01_H

--- a/src/native/host/rf24g/rf24g_hal.h
+++ b/src/native/host/rf24g/rf24g_hal.h
@@ -1,0 +1,78 @@
+// rf24g_hal.h - Platform shim for the rf24g nRF24L01+ driver
+//
+// nrf24l01.c and rf24g_host.c talk to hardware ONLY through this interface
+// -- no pico-sdk (or any other platform SDK) calls outside the HAL
+// implementation file. That keeps sn30_protocol.h, nrf24l01.c and
+// rf24g_host.c portable: a future ESP32-S3 or nRF52840 build needs a new
+// rf24g_hal_<platform>.c and nothing else.
+//
+// RP2040/RP2350 implementation: rf24g_hal_rp2040.c (spi0 + gpio +
+// hardware_alarm).
+//
+// Time-critical note: every rf24g_hal_* function reachable from rf24g_host.c's
+// radio ISR / dwell-alarm chain (ce, spi_xfer, time_us, alarm_schedule) is
+// __not_in_flash_func in rf24g_hal_rp2040.c -- see rf24g_host.c's file header
+// for why. init and irq_attach are one-time setup calls from ordinary
+// (flash-resident) init code and are not part of that chain.
+
+#ifndef RF24G_HAL_H
+#define RF24G_HAL_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+// __not_in_flash_func (RAM function placement, for code that must survive
+// running mid-flash-erase) is a pico-sdk macro, normally picked up
+// transitively by files that already include hardware/*.h or pico/*.h.
+// rf24g_host.c and nrf24l01.c deliberately include neither -- this header is
+// the one designated portability seam -- so it is pulled in from here, the
+// one place platform-specific detail is allowed to leak in. platform.h
+// already no-ops this macro on ESP32/NRF/CH32; guard against a conflicting
+// redefinition when both headers are included together.
+#if defined(PICO_PLATFORM) || defined(PICO_RP2040) || defined(PICO_RP2350)
+  #include "pico.h"
+#elif !defined(__not_in_flash_func)
+  #define __not_in_flash_func(func_name) func_name
+#endif
+
+// Both callback types fire from interrupt context on RP2040 -- see
+// rf24g_host.c's ISR-driven scheduler and the __not_in_flash_func
+// requirement it documents.
+typedef void (*rf24g_hal_irq_cb_t)(void);
+typedef void (*rf24g_hal_alarm_cb_t)(void);
+
+// One-time bring-up: configures SPI + GPIO for the given pins and claims
+// whatever timer/alarm resource rf24g_hal_alarm_schedule() needs. Does not
+// touch the radio itself -- that is nrf24l01.c's job once this returns.
+void rf24g_hal_init(uint8_t sck, uint8_t mosi, uint8_t miso,
+                     uint8_t csn, uint8_t ce, uint8_t irq);
+
+// Drive CE high/low.
+void rf24g_hal_ce(bool level);
+
+// Full-duplex SPI transaction, CSN handled internally (low -> transfer ->
+// high) -- the nRF24 command byte is framed by CSN, not by a hardware
+// chip-select signal. tx and/or rx may be NULL for a write-only / read-only
+// transfer, matching spi_write_read_blocking()'s contract.
+void rf24g_hal_spi_xfer(const uint8_t* tx, uint8_t* rx, size_t len);
+
+// Attach the falling-edge IRQ handler on the configured IRQ pin. Call once,
+// after the radio itself has been configured (so the IRQ line isn't left
+// floating mid-init). `cb` runs in interrupt context.
+void rf24g_hal_irq_attach(rf24g_hal_irq_cb_t cb);
+
+// Microseconds since boot (wraps at 32 bits). Numerically identical to
+// platform_time_us() on every platform this HAL targets -- rf24g_host.c uses
+// whichever of the two is safe in a given context (this one inside the
+// ISR/alarm chain, platform_time_us() everywhere else) and mixes the
+// resulting values freely.
+uint32_t rf24g_hal_time_us(void);
+
+// Arm a one-shot deadline for absolute time `at_us` (rf24g_hal_time_us()
+// timebase). Firing calls `cb` from interrupt context. There is only ever
+// one dwell deadline live at a time, so a new call before the previous one
+// fires simply replaces it -- callers never need to cancel explicitly.
+void rf24g_hal_alarm_schedule(uint32_t at_us, rf24g_hal_alarm_cb_t cb);
+
+#endif // RF24G_HAL_H

--- a/src/native/host/rf24g/rf24g_hal_rp2040.c
+++ b/src/native/host/rf24g/rf24g_hal_rp2040.c
@@ -1,0 +1,158 @@
+// rf24g_hal_rp2040.c - RP2040/RP2350 HAL for the rf24g nRF24L01+ driver
+//
+// spi0 (the wiring app.h picks -- SCK=6/MOSI=7/MISO=0 is spi0's native
+// pinout, a straight hardware peripheral rather than bit-banged), plain-GPIO
+// CE/CSN/IRQ, and one claimed hardware_alarm for the dwell scheduler. Every
+// pico-sdk call this driver needs lives in this one file -- see rf24g_hal.h.
+//
+// Every function below except rf24g_hal_init() and rf24g_hal_irq_attach() is
+// reachable from rf24g_host.c's radio ISR / dwell-alarm chain, so it carries
+// __not_in_flash_func -- see rf24g_host.c's file header for why this is
+// defense in depth, not fault avoidance. One known, accepted exception:
+// rf24g_hal_alarm_schedule() below calls flash-resident time_us_64() and
+// hardware_alarm_set_target() (confirmed by disassembly on both `pico` and
+// `pico2` builds) despite being __not_in_flash_func itself -- those two
+// callees are veneers into flash and are left that way, same as the
+// pico-sdk IRQ entry dispatchers that dispatch into this file's trampolines
+// in the first place.
+
+#if defined(PICO_PLATFORM) || defined(PICO_RP2040) || defined(PICO_RP2350)
+
+#include "rf24g_hal.h"
+#include "hardware/spi.h"
+#include "hardware/gpio.h"
+#include "hardware/timer.h"
+#include "pico/time.h"
+
+// Never schedule the alarm for "now" -- see rf24g_hal_alarm_schedule(). A few
+// microseconds is comfortably longer than the register write that arms it,
+// and negligible against the 10070us dwell it paces.
+#define RF24G_ALARM_MIN_US      8
+#define RF24G_ALARM_MAX_TRIES   8
+#define RF24G_ALARM_FALLBACK_US 1000
+
+static uint8_t s_pin_csn = 0xFF;
+static uint8_t s_pin_ce  = 0xFF;
+static uint8_t s_pin_irq = 0xFF;
+static int8_t  s_alarm_num = -1;
+
+static rf24g_hal_irq_cb_t   s_irq_cb   = NULL;
+static rf24g_hal_alarm_cb_t s_alarm_cb = NULL;
+
+static void __not_in_flash_func(gpio_irq_trampoline)(uint gpio, uint32_t events)
+{
+    (void)events;
+    if (gpio == s_pin_irq && s_irq_cb) s_irq_cb();
+}
+
+static void __not_in_flash_func(alarm_trampoline)(uint alarm_num)
+{
+    (void)alarm_num;
+    if (s_alarm_cb) s_alarm_cb();
+}
+
+void rf24g_hal_init(uint8_t sck, uint8_t mosi, uint8_t miso,
+                     uint8_t csn, uint8_t ce, uint8_t irq)
+{
+    s_pin_csn = csn;
+    s_pin_ce  = ce;
+    s_pin_irq = irq;
+
+    // 8 MHz -- the nRF24L01+ tolerates up to 10, per the app.h pin comment.
+    spi_init(spi0, 8 * 1000 * 1000);
+    spi_set_format(spi0, 8, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
+    gpio_set_function(sck,  GPIO_FUNC_SPI);
+    gpio_set_function(mosi, GPIO_FUNC_SPI);
+    gpio_set_function(miso, GPIO_FUNC_SPI);
+
+    // CSN: plain GPIO, idle high. The nRF24 command byte is framed by CSN
+    // going low, not by a hardware chip-select signal -- same pattern as
+    // w5500.c's cs_low()/cs_high().
+    gpio_init(csn);
+    gpio_set_dir(csn, GPIO_OUT);
+    gpio_put(csn, 1);
+
+    // CE: plain GPIO, starts low (standby). Held high continuously while
+    // listening, dropped briefly around every channel change -- see
+    // rf24g_host.c's radio_retune().
+    gpio_init(ce);
+    gpio_set_dir(ce, GPIO_OUT);
+    gpio_put(ce, 0);
+
+    // IRQ: input, active low. Most nRF24L01+ breakout boards carry their own
+    // pull-up on this line; an internal one costs nothing and protects an
+    // unpopulated board.
+    gpio_init(irq);
+    gpio_set_dir(irq, GPIO_IN);
+    gpio_pull_up(irq);
+
+    int alarm = hardware_alarm_claim_unused(true);
+    s_alarm_num = (int8_t)alarm;
+    hardware_alarm_set_callback((uint)s_alarm_num, alarm_trampoline);
+}
+
+void __not_in_flash_func(rf24g_hal_ce)(bool level)
+{
+    gpio_put(s_pin_ce, level);
+}
+
+void __not_in_flash_func(rf24g_hal_spi_xfer)(const uint8_t* tx, uint8_t* rx, size_t len)
+{
+    gpio_put(s_pin_csn, 0);
+    if (tx && rx)      spi_write_read_blocking(spi0, tx, rx, len);
+    else if (rx)       spi_read_blocking(spi0, 0xFF, rx, len);
+    else if (tx)       spi_write_blocking(spi0, tx, len);
+    gpio_put(s_pin_csn, 1);
+}
+
+void rf24g_hal_irq_attach(rf24g_hal_irq_cb_t cb)
+{
+    s_irq_cb = cb;
+    gpio_set_irq_enabled_with_callback(s_pin_irq, GPIO_IRQ_EDGE_FALL, true,
+                                       gpio_irq_trampoline);
+}
+
+uint32_t __not_in_flash_func(rf24g_hal_time_us)(void)
+{
+    return time_us_32();
+}
+
+void __not_in_flash_func(rf24g_hal_alarm_schedule)(uint32_t at_us, rf24g_hal_alarm_cb_t cb)
+{
+    s_alarm_cb = cb;
+
+    // at_us is on the rf24g_hal_time_us() (== time_us_32()) timebase, but
+    // hardware_alarm_set_target() wants an absolute_time_t (64-bit us since
+    // boot). Compute the delta in 32-bit arithmetic -- correct even across a
+    // time_us_32() wrap, since a dwell deadline is always within tens of
+    // milliseconds of "now" -- then project it onto the 64-bit clock.
+    uint32_t now = time_us_32();
+    int32_t delta = (int32_t)(at_us - now);
+
+    // hardware_alarm_set_target() returns true when the target is already in
+    // the past -- and in that case it does NOT arm the alarm, so the callback
+    // never fires. A deadline that has already slipped is exactly the case
+    // this scheduler hits when an ISR ran late, and a silently-unarmed alarm
+    // stalls the link forever: in PARK or SEARCH no RX interrupt is coming to
+    // re-arm it. So never ask for "now", and if the target is still missed,
+    // push it further out and retry.
+    if (delta < RF24G_ALARM_MIN_US) delta = RF24G_ALARM_MIN_US;
+
+    for (uint8_t tries = 0; tries < RF24G_ALARM_MAX_TRIES; tries++) {
+        if (!hardware_alarm_set_target((uint)s_alarm_num,
+                                       make_timeout_time_us((uint64_t)delta))) {
+            return;   // armed
+        }
+        delta += RF24G_ALARM_MIN_US;
+    }
+
+    // Last resort: arm well clear of now, which cannot be missed. Losing the
+    // alarm entirely would stall the scheduler with nothing to restart it, so
+    // a late hop beats no hop. (No printf here -- this runs in ISR context,
+    // and stdio is flash-resident; see the __not_in_flash_func rationale in
+    // rf24g_hal.h.)
+    hardware_alarm_set_target((uint)s_alarm_num,
+                              make_timeout_time_us(RF24G_ALARM_FALLBACK_US));
+}
+
+#endif // PICO_PLATFORM || PICO_RP2040 || PICO_RP2350

--- a/src/native/host/rf24g/rf24g_host.c
+++ b/src/native/host/rf24g/rf24g_host.c
@@ -23,37 +23,22 @@
 //
 // Both handlers -- and everything they call, transitively -- are
 // __not_in_flash_func. This is defense in depth, NOT fault avoidance: every
-// flash write in this codebase (core/services/storage/flash.c's
-// flash_write_page()/flash_erase_sector()) disables core-0 interrupts for
-// the entire XIP-off window, so the radio ISR cannot fire mid-write at all
-// regardless of where its code lives. __not_in_flash_func here is a second,
-// independent guarantee that doesn't depend on that interrupt-disable
-// window staying as wide as it is today -- if it were ever narrowed, a
-// flash-resident handler pulled in mid-erase would hard-fault immediately
-// instead of working by accident. (The ISR entry path itself --
-// ram_vector_table's flash-resident dispatchers before control reaches this
-// file's RAM trampolines in rf24g_hal_rp2040.c -- is not fully RAM-resident
-// regardless; that's accepted for the same reason: interrupts are off, so
-// it can't execute mid-write either.)
+// flash write in this codebase disables core-0 interrupts for the entire
+// XIP-off window, so the radio ISR can't fire mid-write regardless of where
+// its code lives. This is a second, independent guarantee against that
+// window ever narrowing -- if it did, a flash-resident handler pulled in
+// mid-erase would hard-fault instead of working by accident. A ~45ms sector
+// erase costs roughly 3-9 missed dwells at the 10070us dwell period;
+// MAX_MISSES (128, ~1.29s) tolerates that without dropping the link.
 //
-// The real, non-hypothetical cost of a flash write while the controller is
-// linked: interrupts off for a ~4KB sector erase (~45ms, flash_erase_sector())
-// costs roughly 3-9 missed dwells at the 10070us DWELL_US period. MAX_MISSES
-// is 128 (~1.29s) before the link is considered dropped, and every received
-// frame re-syncs both hop index and phase (see handle_frame()), so the link
-// rides out an erase without dropping.
+// __not_in_flash_func places a function's OWN code in RAM, not its callees',
+// so it's repeated down the whole ISR/alarm call chain (this file,
+// nrf24l01.c, rf24g_hal_rp2040.c). Code NOT reachable from that chain (init,
+// the public task/stats/pairing entry points) is free to live in flash.
 //
-// __not_in_flash_func places a function's OWN code in RAM; it does nothing
-// for functions it calls, so the attribute has to be repeated all the way
-// down the call chain (this file, nrf24l01.c, rf24g_hal_rp2040.c). Anything
-// NOT reachable from the ISR/alarm chain (init, the public task/stats/pairing
-// entry points called from ordinary core-0 code) is free to live in flash
-// and use platform_time_us()/platform_time_ms() normally.
-//
-// rf24g_host_task(), called from core 0, does NO radio I/O at all -- it only
-// drains the ring buffer, builds input_event_t's and calls
-// router_submit_input(), plus the non-timing-critical pairing-confirmation
-// and per-second stats bookkeeping.
+// rf24g_host_task(), called from core 0, does NO radio I/O -- it only drains
+// the ring buffer, builds input_event_t's and calls router_submit_input(),
+// plus pairing-confirmation and per-second stats bookkeeping.
 
 #include "rf24g_host.h"
 #include "rf24g_hal.h"       // must precede sn30_protocol.h: this is where
@@ -137,21 +122,13 @@ typedef enum {
 #define RF24G_HIST_BUCKETS 6
 
 typedef struct {
-    // Pipe 0 (the only pipe -- see RF24G_PIPE_MASK) is always enabled --
-    // there is no "claimed" flag to track here. This struct is purely
-    // link/scheduling state; whether the controller has ever been heard from
-    // this boot lives in s_seen instead.
+    // Pipe 0 is always enabled -- no "claimed" flag needed here. Purely
+    // link/scheduling state; s_seen tracks whether ever heard from this boot.
     //
-    // linked/misses/pkts_total/pkts_window/period_us are `volatile`-qualified
-    // fields: they're written from ISR/alarm context (handle_frame(),
-    // on_alarm(), drop_slot_link()) and read (pkts_window: read AND cleared)
-    // from ordinary core-0 task context (rf24g_host_is_connected(),
-    // rf24g_host_get_device_count(), rf24g_host_print_stats(),
-    // rf24g_host_task(), pairing_confirm_task()) -- same cross-context
-    // pattern as s_seen/s_unlink_pending/s_pair_result below, so they need
-    // the same guarantee against the compiler caching a stale value across a
-    // call that doesn't itself write them. The remaining fields never leave
-    // ISR/alarm context and don't need it.
+    // The `volatile` fields below cross the ISR/core-0 boundary (written in
+    // handle_frame()/on_alarm(), read or read-and-cleared from ordinary
+    // core-0 task functions), same pattern as s_seen/s_unlink_pending below.
+    // The rest never leave ISR/alarm context and don't need it.
     volatile bool linked;  // has received at least one ordinary (non-probe) frame
     bool     confirmed;    // a SECOND frame arrived after the acquisition jump
 
@@ -172,41 +149,29 @@ typedef struct {
 
 static bool s_initialized = false;
 
-// volatile: written from ISR/alarm context (on_radio_irq(), on_alarm(),
-// enter_park(), enter_search(), pairing_end()) and read from core-0 task
-// context (rf24g_host_is_pairing(), rf24g_host_state_name()) -- same
-// cross-context pattern as the other volatile state in this file.
-static volatile rf24g_link_state_t s_state = RF24G_LINK_PARK;
-static volatile uint8_t   s_cur_ch     = SN30_PARK_CH;  // also read from
-                                                   // rf24g_host_print_stats()
-                                                   // on core 0
-static bool               s_following  = false;  // whether the current dwell
-                                                   // is following the link
-                                                   // (false during PARK/
-                                                   // SEARCH/PAIRING)
+// Both volatile: written from ISR/alarm context, read from core-0 task
+// functions (rf24g_host_is_pairing(), rf24g_host_state_name(),
+// rf24g_host_print_stats()).
+static volatile rf24g_link_state_t s_state  = RF24G_LINK_PARK;
+static volatile uint8_t            s_cur_ch = SN30_PARK_CH;
+static bool               s_following  = false;  // dwell is following the
+                                                   // link? false in PARK/
+                                                   // SEARCH/PAIRING
 static uint8_t            s_sweep_idx  = 0;    // SEARCH sweep position
 static uint16_t           s_sweep_hops = 0;
 
 // The controller's link/scheduling state.
 static rf24g_slot_t s_slot;
 
-// Receiver identity: an FNV-1a hash of the board's own factory-programmed
-// unique ID, computed once in rf24g_host_init_pins() (before radio_init())
-// and never touched again -- see sn30_protocol.h's "Receiver identity". It
-// comes out identical on every boot by construction, so there is nothing to
-// persist to flash and nothing lost on a power cycle; a controller paired
-// to this board stays paired across a reboot or a reflash, and needs
-// re-pairing only if it moves to a different board.
+// FNV-1a hash of the board's factory unique ID, computed once in
+// rf24g_host_init_pins() -- see sn30_protocol.h's "Receiver identity". Comes
+// out identical on every boot, so a controller stays paired across a reboot
+// or reflash and needs re-pairing only if it moves to a different board.
 static uint8_t s_receiver_id[4];
 
-// Whether the controller has been heard from (received at least one LINKED
-// frame, i.e. actually paired and talking) at any point this boot. The pipe
-// is always open (see RF24G_PIPE_MASK in apply_pipe_addresses()), so
-// nothing needs to be tracked to gate reception; this exists purely so
-// rf24g_host_print_stats() can report whether the controller has ever
-// checked in this boot, distinct from whether it's linked right now.
-// ISR-side single writer (handle_frame()), core-0 reader -- volatile and a
-// plain assignment are sufficient, no lock needed.
+// Whether the controller has ever linked this boot -- diagnostic only, for
+// rf24g_host_print_stats(); the pipe is always open regardless. ISR-side
+// single writer (handle_frame()), core-0 reader.
 static volatile bool s_seen = false;
 
 static uint32_t s_stats_window_ms = 0;
@@ -228,13 +193,9 @@ static volatile uint8_t s_ring_head = 0;   // ISR writes
 static volatile uint8_t s_ring_tail = 0;   // rf24g_host_task() reads
 
 // Whether the ISR unlinked the controller and its player registration still
-// needs tearing down. The ISR must not do it itself: remove_players_by_address()
-// lives in manager.c, i.e. in flash, and calling it from the RAM-resident
-// ISR/alarm chain would break the __not_in_flash_func discipline this
-// file's header documents (interrupts are actually off for the whole of a
-// flash write, so this specific call wouldn't fault today -- see the header
-// for why the discipline is kept anyway). The ISR sets this flag;
-// rf24g_host_task() does the actual removal on core 0.
+// needs tearing down. remove_players_by_address() is flash-resident, so the
+// ISR can't call it directly (see file header); it sets this flag instead,
+// and rf24g_host_task() does the actual removal on core 0.
 static volatile bool s_unlink_pending = false;   // ISR sets, task clears
 
 static void __not_in_flash_func(ring_push)(uint8_t b2, uint8_t b3)
@@ -272,28 +233,16 @@ static uint16_t s_pair_requests;
 static uint16_t s_pair_cycle_reqs;
 static uint8_t  s_pair_reply[SN30_PAIR_RSP_LEN];
 
-// Tracks whether pairing_end() most recently accepted a claim that hasn't
-// yet been confirmed by an actual frame arriving. pairing_end() only sees
-// "the controller stopped asking", which does not by itself mean the
-// controller took the address -- so pairing_confirm_task() separately
-// watches pkts_total for PAIR_CONFIRM_US and reports whichever way it goes.
-// Purely diagnostic: the pipe is already open unconditionally (see
-// RF24G_PIPE_MASK), so there is nothing to roll back either way. Note that
-// "never confirmed" does NOT mean "never taken": a controller that already
-// held this address, or that will not transmit until power-cycled, is
-// silent here and confirms nothing, yet is paired and links on its next
-// power-on.
+// Tracks whether pairing_end() accepted a claim not yet confirmed by an
+// actual frame arriving -- "controller stopped asking" isn't proof it took
+// the address, so pairing_confirm_task() separately watches pkts_total for
+// PAIR_CONFIRM_US. Purely diagnostic: the pipe is already open regardless,
+// so there's nothing to roll back. "Never confirmed" does NOT mean "never
+// taken": a controller that already held this address, or won't transmit
+// until power-cycled, stays silent here yet links on its next power-on.
 //
-// Written by pairing_end() in alarm/ISR context, read and cleared by
-// pairing_confirm_task() on core 0, so volatile like s_pair_result and
-// s_unlink_pending. The deadline is on the rf24g_hal_time_us() timebase,
-// NOT platform_time_ms(): pairing_end() is reachable from on_alarm(), and
-// platform_time_ms() is flash-resident, which is exactly what this file's
-// __not_in_flash_func call graph exists to keep out of the ISR chain (see
-// the file header). rf24g_hal_time_us() is __not_in_flash_func and already
-// the ISR chain's clock everywhere else. PAIR_CONFIRM_US is 8s, far inside
-// the ~35 minutes of headroom the signed-difference comparison has before
-// a uint32 us counter wrap could confuse it.
+// Deadline uses rf24g_hal_time_us(), not platform_time_ms() (flash-resident,
+// unsafe from on_alarm() -- see file header).
 static volatile bool     s_pair_prov_active = false;
 static volatile uint32_t s_pair_prov_pkts = 0;
 static volatile uint32_t s_pair_prov_deadline_us = 0;
@@ -703,43 +652,27 @@ static void __not_in_flash_func(on_alarm)(void)
         // handle_frame()).
         s->hop_idx = sn30_next_idx(s->hop_idx);
 
-        // Advance the anchor by exactly one period -- NOT to `now`. `now` is
-        // the previous deadline, which already includes HOP_GUARD_US, so
-        // re-anchoring there slips the whole schedule HOP_GUARD_US later on
-        // every miss; after P/HOP_GUARD_US (7) consecutive misses the dwell
-        // no longer contains the transmitter's slot at all, and the link
-        // cannot re-sync until it coincides by luck. Keeping the anchor on
-        // the transmitter's own grid makes the free-run drift-free; a
-        // received frame still re-syncs index AND phase in handle_frame()
-        // exactly as before.
+        // Advance by exactly one period, NOT to `now` -- `now` already
+        // includes HOP_GUARD_US, so re-anchoring there slips the schedule on
+        // every miss until the dwell no longer contains the transmitter's
+        // slot at all. Staying on the transmitter's own grid is drift-free;
+        // a received frame still re-syncs both in handle_frame().
         s->last_rx_us += s->period_us;
 
-        // Catch up in whole periods if a long stall (e.g. a flash sector
-        // erase, which runs with core-0 interrupts off) left the anchor more
-        // than one period behind, rather than letting schedule_next()'s
-        // `deadline = now` clamp spin the alarm at RF24G_ALARM_MIN_US
-        // intervals.
-        //
-        // BOUNDED, with a fallback, because this runs in alarm-ISR context
-        // where an unbounded loop is a hang and not merely a slowdown.
-        // period_us should never be 0 -- it is seeded to DWELL_US and only
-        // ever reassigned from rf24g_div_u32() -- but rf24g_div_u32() guards
-        // its own divisor for exactly the "don't trust that invariant
-        // forever" reason, and a 0 reaching here would spin this loop
-        // forever rather than just degrade a dwell. 8 periods is ~81ms,
-        // comfortably past the ~45ms worst-case flash_erase_sector() stall
-        // this exists to absorb.
+        // Catch up in whole periods if a long stall (e.g. a flash erase,
+        // which runs with interrupts off) left the anchor over a period
+        // behind. Bounded, with a fallback below, because this is alarm-ISR
+        // context where an unbounded loop is a hang, not a slowdown. 8
+        // periods (~81ms) comfortably covers the ~45ms worst-case erase
+        // stall this exists to absorb.
         for (uint8_t catchup = 0;
              catchup < 8 && (int32_t)((s->last_rx_us + s->period_us) - now) < 0;
              catchup++) {
             s->last_rx_us += s->period_us;
         }
 
-        // Still behind after the bound: a stall far longer than this
-        // arithmetic can absorb, or a degenerate period. Give up on holding
-        // the transmitter's grid and take the phase slip ONCE -- which is
-        // what the pre-fix code did on every single miss. The next received
-        // frame re-syncs both phase and index in handle_frame() regardless.
+        // Still behind after the bound: take the phase slip once rather than
+        // spin further. The next received frame re-syncs regardless.
         if ((int32_t)((s->last_rx_us + s->period_us) - now) < 0)
             s->last_rx_us = now;
 

--- a/src/native/host/rf24g/rf24g_host.c
+++ b/src/native/host/rf24g/rf24g_host.c
@@ -1,0 +1,1134 @@
+// rf24g_host.c - SN30 2.4G link state machine, scheduler, pairing
+//
+// See rf24g_host.h for the public API and sn30_protocol.h for the protocol
+// this implements. This file is the third of three layers (rf24g_hal ->
+// nrf24l01 -> here) so the protocol logic is testable independently of the
+// chip and the chip independently of the board.
+//
+// ---- Why this is interrupt-driven, not polled ----------------------------
+//
+// core0_main() (src/main.c) is an unthrottled while(1) running LED, player,
+// storage, input, output and app tasks. Any one of them stalling past a
+// ~10ms dwell loses a packet -- that stall is exactly what capped the
+// ESP8266 reference receiver at 9-10 pkt/s while its Wi-Fi stack ran
+// alongside a polled radioPump(). So the radio here runs entirely off
+// interrupts:
+//
+//   - nRF24 IRQ pin, falling edge (on_radio_irq): drains the RX FIFO (3
+//     deep, keeps the newest valid frame), decodes it, pushes it to a
+//     lock-free ring buffer, waits ACK_GUARD_US for the hardware auto-ACK to
+//     clear the antenna, then retunes and re-arms the dwell alarm.
+//   - A hardware alarm (on_alarm) fires when a dwell expires with nothing
+//     received: advances the index, retunes anyway, counts a miss.
+//
+// Both handlers -- and everything they call, transitively -- are
+// __not_in_flash_func. This is defense in depth, NOT fault avoidance: every
+// flash write in this codebase (core/services/storage/flash.c's
+// flash_write_page()/flash_erase_sector()) disables core-0 interrupts for
+// the entire XIP-off window, so the radio ISR cannot fire mid-write at all
+// regardless of where its code lives. __not_in_flash_func here is a second,
+// independent guarantee that doesn't depend on that interrupt-disable
+// window staying as wide as it is today -- if it were ever narrowed, a
+// flash-resident handler pulled in mid-erase would hard-fault immediately
+// instead of working by accident. (The ISR entry path itself --
+// ram_vector_table's flash-resident dispatchers before control reaches this
+// file's RAM trampolines in rf24g_hal_rp2040.c -- is not fully RAM-resident
+// regardless; that's accepted for the same reason: interrupts are off, so
+// it can't execute mid-write either.)
+//
+// The real, non-hypothetical cost of a flash write while the controller is
+// linked: interrupts off for a ~4KB sector erase (~45ms, flash_erase_sector())
+// costs roughly 3-9 missed dwells at the 10070us DWELL_US period. MAX_MISSES
+// is 128 (~1.29s) before the link is considered dropped, and every received
+// frame re-syncs both hop index and phase (see handle_frame()), so the link
+// rides out an erase without dropping.
+//
+// __not_in_flash_func places a function's OWN code in RAM; it does nothing
+// for functions it calls, so the attribute has to be repeated all the way
+// down the call chain (this file, nrf24l01.c, rf24g_hal_rp2040.c). Anything
+// NOT reachable from the ISR/alarm chain (init, the public task/stats/pairing
+// entry points called from ordinary core-0 code) is free to live in flash
+// and use platform_time_us()/platform_time_ms() normally.
+//
+// rf24g_host_task(), called from core 0, does NO radio I/O at all -- it only
+// drains the ring buffer, builds input_event_t's and calls
+// router_submit_input(), plus the non-timing-critical pairing-confirmation
+// and per-second stats bookkeeping.
+
+#include "rf24g_host.h"
+#include "rf24g_hal.h"       // must precede sn30_protocol.h: this is where
+                             // __not_in_flash_func gets pulled in (see
+                             // rf24g_hal.h's header comment), and
+                             // sn30_identity()/sn30_next_idx() below need it
+#include "sn30_protocol.h"
+#include "nrf24l01.h"
+#include "core/router/router.h"
+#include "core/input_event.h"
+#include "core/buttons.h"
+#include "core/services/players/manager.h"
+#include "platform/platform.h"
+#include <stdio.h>
+#include <string.h>
+
+// ============================================================================
+// TUNING CONSTANTS -- all empirically derived on real hardware against a
+// real SN30 2.4G controller. Do not "fix" these to look more plausible;
+// several already-plausible-looking values (10100, 10204) were measured and
+// then found wrong -- see DWELL_US.
+// ============================================================================
+
+// Dwell period: the transmitter's real hop rate, not a round number. Median
+// interval between ADJACENT arrivals in a 128-frame contiguous trace, spread
+// 10040-10110us. A naive sum(inter-arrival)/sum(counter-delta) estimator
+// looks more rigorous but is wrong -- it averages in pairs that span a
+// blackout, exactly where the counter and the clock disagree (measured
+// 10204us against the true 10070us). The period estimate in this file is
+// seeded with this constant and then refined the same restricted way -- see
+// rf24g_slot_t.period_us.
+#define DWELL_US 10070
+
+// Extra late margin on the hop deadline, beyond a dwell period. Packets
+// arrive at the very end of the dwell (90% in its last eighth once retune
+// timing is right), so waiting a bit past the nominal deadline catches the
+// tail before giving up and advancing anyway.
+#define HOP_GUARD_US 1500
+
+// Hold off the post-receive channel change until the hardware auto-ACK has
+// left the antenna. The ACK starts ~130us after the packet ends and is
+// itself ~300us at 250kbps; retuning inside that window cuts it off or sends
+// it on the wrong channel -- and the controller is waiting on exactly that
+// ACK before it will start hopping. Measured plateau across 0-500us with a
+// real nRF24L01+ (unlike the OEM dongle's slow bit-banged SPI, which never
+// gets there fast enough to matter); kept at the value everything else was
+// tuned around.
+#define ACK_GUARD_US 500
+
+// Consecutive missed dwells, while following a CONFIRMED slot, before
+// dropping it entirely. Two full hop sequences, ~1.4s -- long enough to ride
+// out a stall without abandoning a link that is still there.
+#define MAX_MISSES 128
+
+// One full sweep's worth of hops before SEARCH gives up and returns to PARK.
+// About half a second, matching the original dongle's own sweep length.
+#define SEARCH_HOPS 52
+
+// Misses tolerated on an UNCONFIRMED acquisition (a contact frame that
+// hasn't yet been followed by a second good frame) before giving up on it.
+// Acquisition is best-effort and retries rather than being ridden all the
+// way to MAX_MISSES.
+#define ACQUIRE_MISSES 16
+
+// PARK re-arms RF_CH to the same park channel on this cadence, mirroring the
+// original dongle's own ~500 re-arms/sec, in case the re-arm itself is what
+// keeps its receiver hot for a probe.
+#define PARK_REARM_US 2000
+
+// ============================================================================
+// STATE
+// ============================================================================
+
+typedef enum {
+    RF24G_LINK_PARK,
+    RF24G_LINK_SEARCH,
+    RF24G_LINK_LINKED,
+    RF24G_LINK_PAIRING,
+} rf24g_link_state_t;
+
+#define RF24G_HIST_BUCKETS 6
+
+typedef struct {
+    // Pipe 0 (the only pipe -- see RF24G_PIPE_MASK) is always enabled --
+    // there is no "claimed" flag to track here. This struct is purely
+    // link/scheduling state; whether the controller has ever been heard from
+    // this boot lives in s_seen instead.
+    //
+    // linked/misses/pkts_total/pkts_window/period_us are `volatile`-qualified
+    // fields: they're written from ISR/alarm context (handle_frame(),
+    // on_alarm(), drop_slot_link()) and read (pkts_window: read AND cleared)
+    // from ordinary core-0 task context (rf24g_host_is_connected(),
+    // rf24g_host_get_device_count(), rf24g_host_print_stats(),
+    // rf24g_host_task(), pairing_confirm_task()) -- same cross-context
+    // pattern as s_seen/s_unlink_pending/s_pair_result below, so they need
+    // the same guarantee against the compiler caching a stale value across a
+    // call that doesn't itself write them. The remaining fields never leave
+    // ISR/alarm context and don't need it.
+    volatile bool linked;  // has received at least one ordinary (non-probe) frame
+    bool     confirmed;    // a SECOND frame arrived after the acquisition jump
+
+    uint8_t  hop_idx;      // this slot's predicted/last-known hop index
+    uint8_t  last_ctr;     // last raw byte10 (hop index at the time of RX)
+    uint32_t last_rx_us;   // rf24g_hal_time_us() of the last reception
+    volatile uint32_t period_us;  // measured inter-arrival period; DWELL_US until measured
+    uint32_t burst_dt_us;  // accumulator: sum of dt over consecutive dc==1 pairs
+    uint32_t burst_n;      // accumulator: count of the same -- see handle_frame()
+    volatile uint16_t misses;  // consecutive missed dwells while this slot is followed
+
+    // Diagnostics -- see rf24g_host_print_stats().
+    volatile uint32_t pkts_total;
+    volatile uint32_t pkts_window;
+    uint32_t pps;
+    uint16_t inter_hist[RF24G_HIST_BUCKETS];
+} rf24g_slot_t;
+
+static bool s_initialized = false;
+
+// volatile: written from ISR/alarm context (on_radio_irq(), on_alarm(),
+// enter_park(), enter_search(), pairing_end()) and read from core-0 task
+// context (rf24g_host_is_pairing(), rf24g_host_state_name()) -- same
+// cross-context pattern as the other volatile state in this file.
+static volatile rf24g_link_state_t s_state = RF24G_LINK_PARK;
+static volatile uint8_t   s_cur_ch     = SN30_PARK_CH;  // also read from
+                                                   // rf24g_host_print_stats()
+                                                   // on core 0
+static bool               s_following  = false;  // whether the current dwell
+                                                   // is following the link
+                                                   // (false during PARK/
+                                                   // SEARCH/PAIRING)
+static uint8_t            s_sweep_idx  = 0;    // SEARCH sweep position
+static uint16_t           s_sweep_hops = 0;
+
+// The controller's link/scheduling state.
+static rf24g_slot_t s_slot;
+
+// Receiver identity: an FNV-1a hash of the board's own factory-programmed
+// unique ID, computed once in rf24g_host_init_pins() (before radio_init())
+// and never touched again -- see sn30_protocol.h's "Receiver identity". It
+// comes out identical on every boot by construction, so there is nothing to
+// persist to flash and nothing lost on a power cycle; a controller paired
+// to this board stays paired across a reboot or a reflash, and needs
+// re-pairing only if it moves to a different board.
+static uint8_t s_receiver_id[4];
+
+// Whether the controller has been heard from (received at least one LINKED
+// frame, i.e. actually paired and talking) at any point this boot. The pipe
+// is always open (see RF24G_PIPE_MASK in apply_pipe_addresses()), so
+// nothing needs to be tracked to gate reception; this exists purely so
+// rf24g_host_print_stats() can report whether the controller has ever
+// checked in this boot, distinct from whether it's linked right now.
+// ISR-side single writer (handle_frame()), core-0 reader -- volatile and a
+// plain assignment are sufficient, no lock needed.
+static volatile bool s_seen = false;
+
+static uint32_t s_stats_window_ms = 0;
+
+// ---- RX ring buffer (ISR producer, rf24g_host_task() consumer) -----------
+// Single-producer/single-consumer, power-of-two size so the index wrap is a
+// mask. Decoding happens here (in the ISR) so the ring only ever carries the
+// two raw button bytes -- router_submit_input() itself is never called from
+// interrupt context.
+#define RF24G_RING_SIZE 16   // must stay a power of 2
+
+typedef struct {
+    uint8_t raw_b2;
+    uint8_t raw_b3;
+} rf24g_rx_item_t;
+
+static volatile rf24g_rx_item_t s_ring[RF24G_RING_SIZE];
+static volatile uint8_t s_ring_head = 0;   // ISR writes
+static volatile uint8_t s_ring_tail = 0;   // rf24g_host_task() reads
+
+// Whether the ISR unlinked the controller and its player registration still
+// needs tearing down. The ISR must not do it itself: remove_players_by_address()
+// lives in manager.c, i.e. in flash, and calling it from the RAM-resident
+// ISR/alarm chain would break the __not_in_flash_func discipline this
+// file's header documents (interrupts are actually off for the whole of a
+// flash write, so this specific call wouldn't fault today -- see the header
+// for why the discipline is kept anyway). The ISR sets this flag;
+// rf24g_host_task() does the actual removal on core 0.
+static volatile bool s_unlink_pending = false;   // ISR sets, task clears
+
+static void __not_in_flash_func(ring_push)(uint8_t b2, uint8_t b3)
+{
+    uint8_t next = (uint8_t)((s_ring_head + 1) & (RF24G_RING_SIZE - 1));
+    if (next == s_ring_tail) return;   // full -- drop rather than corrupt
+    s_ring[s_ring_head].raw_b2 = b2;
+    s_ring[s_ring_head].raw_b3 = b3;
+    s_ring_head = next;
+}
+
+// ---- Pairing rendezvous state ---------------------------------------------
+// Driven from the same alarm as the link scheduler (on_alarm dispatches to
+// pairing_on_alarm() while s_state == RF24G_LINK_PAIRING) and the same IRQ
+// (on_radio_irq dispatches to pairing_on_rx_irq()).
+
+#define PAIR_CYCLES         5
+#define PAIR_PER_CYCLE     25
+#define PAIR_SLOT_US    20000     // reply cadence
+#define PAIR_LISTEN_US 500000     // listening window between TX cycles
+#define PAIR_QUIET_US  250000     // no request for this long => burst is over
+#define PAIR_FIRST_TX_US 346000   // first reply this long after the LAST request
+#define PAIR_WAIT_US 45000000     // give up if no controller ever asks
+#define PAIR_CONFIRM_US 8000000   // a claim is provisional until frames arrive
+#define PAIR_POLL_US     5000     // WAIT-phase polling granularity
+
+typedef enum { PAIR_WAIT, PAIR_TX, PAIR_RX } pair_phase_t;
+
+static pair_phase_t s_pair_phase;
+static uint8_t  s_pair_cycle;
+static uint8_t  s_pair_idx;
+static uint32_t s_pair_last_req_us;
+static uint32_t s_pair_started_us;
+static uint16_t s_pair_requests;
+static uint16_t s_pair_cycle_reqs;
+static uint8_t  s_pair_reply[SN30_PAIR_RSP_LEN];
+
+// Tracks whether pairing_end() most recently accepted a claim that hasn't
+// yet been confirmed by an actual frame arriving. pairing_end() only sees
+// "the controller stopped asking", which does not by itself mean the
+// controller took the address -- so pairing_confirm_task() separately
+// watches pkts_total for PAIR_CONFIRM_US and reports whichever way it goes.
+// Purely diagnostic: the pipe is already open unconditionally (see
+// RF24G_PIPE_MASK), so there is nothing to roll back either way. Note that
+// "never confirmed" does NOT mean "never taken": a controller that already
+// held this address, or that will not transmit until power-cycled, is
+// silent here and confirms nothing, yet is paired and links on its next
+// power-on.
+//
+// Written by pairing_end() in alarm/ISR context, read and cleared by
+// pairing_confirm_task() on core 0, so volatile like s_pair_result and
+// s_unlink_pending. The deadline is on the rf24g_hal_time_us() timebase,
+// NOT platform_time_ms(): pairing_end() is reachable from on_alarm(), and
+// platform_time_ms() is flash-resident, which is exactly what this file's
+// __not_in_flash_func call graph exists to keep out of the ISR chain (see
+// the file header). rf24g_hal_time_us() is __not_in_flash_func and already
+// the ISR chain's clock everywhere else. PAIR_CONFIRM_US is 8s, far inside
+// the ~35 minutes of headroom the signed-difference comparison has before
+// a uint32 us counter wrap could confuse it.
+static volatile bool     s_pair_prov_active = false;
+static volatile uint32_t s_pair_prov_pkts = 0;
+static volatile uint32_t s_pair_prov_deadline_us = 0;
+
+// pairing_end() runs in ISR/alarm context and must not call printf itself
+// (printf is flash-resident, like everything else that chain avoids -- see
+// the file header). It leaves the outcome here instead; rf24g_host_task()
+// (ordinary core-0 context) reports it on its next call.
+typedef enum { PAIR_RESULT_NONE, PAIR_RESULT_ACCEPTED, PAIR_RESULT_REJECTED } pair_result_t;
+static volatile pair_result_t s_pair_result = PAIR_RESULT_NONE;
+
+// ============================================================================
+// FORWARD DECLARATIONS (the ISR/alarm call graph is mutually recursive)
+// ============================================================================
+static void __not_in_flash_func(on_radio_irq)(void);
+static void __not_in_flash_func(on_alarm)(void);
+static void __not_in_flash_func(enter_park)(void);
+static void __not_in_flash_func(enter_search)(void);
+static void __not_in_flash_func(schedule_next)(void);
+static void __not_in_flash_func(pairing_on_rx_irq)(void);
+static void __not_in_flash_func(pairing_on_alarm)(void);
+static void __not_in_flash_func(pairing_listen)(void);
+static void __not_in_flash_func(pairing_switch_tx)(void);
+static void __not_in_flash_func(pairing_send_reply)(void);
+static void __not_in_flash_func(pairing_end)(bool claim);
+static void __not_in_flash_func(apply_pipe_addresses)(void);
+static void __not_in_flash_func(drop_slot_link)(void);
+
+// ============================================================================
+// PIPE ADDRESSING
+// ============================================================================
+
+#define RF24G_PIPE_MASK 0x01   // pipe 0 only -- see the EN_RXADDR comment below
+
+static void __not_in_flash_func(apply_pipe_addresses)(void)
+{
+    uint8_t addr0[5];
+    sn30_identity(s_receiver_id, addr0);
+
+    nrf24_write_reg_buf(NRF24_REG_RX_ADDR_P0, addr0, NRF24_ADDR_LEN);
+
+    // The receiver's identity is permanent, derived once from the board's
+    // unique ID (see sn30_protocol.h's "Receiver identity"), so pipe 0 is
+    // enabled UNCONDITIONALLY -- there is no "claimed" bitmap to gate this
+    // on.
+    nrf24_write_reg(NRF24_REG_EN_RXADDR, RF24G_PIPE_MASK);
+
+    // TX_ADDR only matters for the auto-ACK path, which sources from the
+    // matching pipe's own address regardless -- set to the receiver's
+    // identity for parity with the OEM dongle, which writes it on every
+    // boot even though it never transmits a payload during an ordinary
+    // link.
+    nrf24_write_reg_buf(NRF24_REG_TX_ADDR, addr0, NRF24_ADDR_LEN);
+}
+
+// ============================================================================
+// RADIO BRING-UP
+// ============================================================================
+
+static void radio_init(void)
+{
+    nrf24_flush_rx();
+    nrf24_flush_tx();
+    nrf24_write_reg(NRF24_REG_STATUS,
+                     (uint8_t)(NRF24_STATUS_RX_DR | NRF24_STATUS_TX_DS | NRF24_STATUS_MAX_RT));
+
+    nrf24_write_reg(NRF24_REG_RF_SETUP, 0x27);      // 250 kbps, max PA
+    nrf24_write_reg(NRF24_REG_SETUP_AW, 0x03);      // 5-byte addresses
+    nrf24_write_reg(NRF24_REG_SETUP_RETR, 0x12);    // ARD 500us, 2 retries
+    nrf24_write_reg(NRF24_REG_EN_AA, 0x3F);         // auto-ACK, all pipes --
+                                                     // the controller is the
+                                                     // PTX and expects one
+
+    // ACTIVATE unlocks FEATURE/DYNPD on chip families that ship them
+    // write-protected until toggled once. Harmless on a genuine nRF24L01+.
+    nrf24_activate();
+
+    // -------------------------------------------------------------------
+    // FEATURE = 0x06, NOT 0x07. This is the single most important line in
+    // this file.
+    //
+    // Bit 0 of FEATURE is EN_DYN_ACK, which enables the NO_ACK mechanism.
+    // The SN30 controller's unlinked probe frames ARE sent NO_ACK. A genuine
+    // nRF24L01+ that honours EN_DYN_ACK therefore REFUSES to acknowledge
+    // them -- the controller then waits forever for the ACK it needs before
+    // it will start hopping, and the link never comes up. The OEM dongle's
+    // BK2425 is an nRF24 clone that does NOT implement EN_DYN_ACK the same
+    // way: it ACKs the probe regardless of the flag, which is exactly why
+    // copying its FEATURE=0x07 register dump verbatim is the wrong instinct
+    // on real silicon -- register-identical is not behaviour-identical.
+    //
+    // Measured A/B, cold controller, no OEM dongle present:
+    //
+    //   FEATURE 0x07 (EN_DYN_ACK set, matches the dongle):  3 probes, 0 links
+    //   FEATURE 0x06 (EN_DYN_ACK clear):    1 probe, LINKED 47s of 51, 1500 pkts
+    //
+    // Do NOT "correct" this to match the dongle's own register set. It
+    // looks like a bug. It is the fix.
+    // -------------------------------------------------------------------
+    nrf24_write_reg(NRF24_REG_FEATURE,
+                     (uint8_t)(NRF24_FEATURE_EN_DPL | NRF24_FEATURE_EN_ACK_PAY));
+    nrf24_write_reg(NRF24_REG_DYNPD, 0x3F);   // dynamic payload, all pipes --
+                                               // frames are 13 bytes, not the
+                                               // 32 RX_PW_Pn would claim
+
+    apply_pipe_addresses();
+
+    nrf24_set_channel(SN30_PARK_CH);
+    s_cur_ch = SN30_PARK_CH;
+    nrf24_power_up_rx();
+    rf24g_hal_ce(true);
+}
+
+// ============================================================================
+// LINK STATE MACHINE -- PARK / SEARCH / LINKED
+// ============================================================================
+
+// Drop CE around every channel change so the ~130us PLL settle happens
+// inside the dwell rather than eating into receive time. A genuine
+// nRF24L01+ does not re-lock cleanly on a live retune the way the OEM
+// dongle's BK2425 does with CE held high throughout -- measured ~4x yield
+// with the drop.
+static void __not_in_flash_func(radio_retune)(uint8_t ch)
+{
+    rf24g_hal_ce(false);
+    nrf24_set_channel(ch);
+    rf24g_hal_ce(true);
+    s_cur_ch = ch;
+}
+
+static void __not_in_flash_func(drop_slot_link)(void)
+{
+    if (!s_slot.linked) return;
+    s_slot.linked    = false;
+    s_slot.confirmed = false;
+    s_slot.misses    = 0;
+    // Deferred to rf24g_host_task() -- see s_unlink_pending. This runs in
+    // ISR context via on_alarm()/enter_park(), where a call into
+    // flash-resident manager.c would break the RAM-residency discipline
+    // this file's header documents (see the header for why that discipline
+    // is kept even though interrupts being off for the whole flash write
+    // means it wouldn't actually fault today).
+    s_unlink_pending = true;
+}
+
+// PARK has NO sweep timer -- the dongle parks INDEFINITELY until it hears
+// something, and only sweeps after a contact frame fails to become a link.
+// A periodic sweep is actively harmful: it takes the radio off 2447MHz,
+// which is the only channel a cold controller ever transmits on, measured
+// 2 probes/90s sweeping against 16/120s parked.
+static void __not_in_flash_func(enter_park)(void)
+{
+    s_state      = RF24G_LINK_PARK;
+    s_following  = false;
+    s_sweep_hops = 0;
+
+    // No CE drop here -- the channel isn't changing (this is a re-arm to the
+    // SAME park channel), and the dongle itself never taps CE across
+    // thousands of park re-arms. Dropping CE would cost ~130us of RX
+    // settling on every one of those for nothing.
+    nrf24_set_channel(SN30_PARK_CH);
+    s_cur_ch = SN30_PARK_CH;
+    nrf24_power_up_rx();     // restore PRX mode in case pairing left us in PTX
+    rf24g_hal_ce(true);
+
+    drop_slot_link();
+
+    rf24g_hal_alarm_schedule(rf24g_hal_time_us() + PARK_REARM_US, on_alarm);
+}
+
+// SEARCH is a second, independent way in: sweeping and hopping both
+// traverse the same 16 channels, so a coincidence with a controller that is
+// already hopping (or an already-linked one whose receiver went away) is
+// guaranteed within a bounded time, with no contact packet required at all.
+static void __not_in_flash_func(enter_search)(void)
+{
+    s_state      = RF24G_LINK_SEARCH;
+    s_following  = false;
+    s_sweep_hops = 0;
+
+    s_sweep_idx = sn30_next_idx(s_sweep_idx);
+    radio_retune(SN30_HOP_TABLE[s_sweep_idx]);
+    rf24g_hal_alarm_schedule(rf24g_hal_time_us() + DWELL_US, on_alarm);
+}
+
+#define RF24G_HIST_ADD(s, dt_us) do { \
+    uint32_t _ms = (dt_us) / 1000; \
+    uint8_t _b = (_ms < 8) ? 0 : (_ms < 9) ? 1 : (_ms < 11) ? 2 : \
+                 (_ms < 13) ? 3 : (_ms < 20) ? 4 : 5; \
+    if ((s)->inter_hist[_b] < 0xFFFF) (s)->inter_hist[_b]++; \
+} while (0)
+
+// If the controller is linked, retune to its predicted next hop index and
+// arm the alarm for its deadline (predicted arrival = last_rx_us +
+// period_us, deadline = predicted + HOP_GUARD_US). If it isn't linked,
+// there is nothing to follow -- park.
+static void __not_in_flash_func(schedule_next)(void)
+{
+    if (!s_slot.linked) {
+        enter_park();
+        return;
+    }
+
+    uint32_t now = rf24g_hal_time_us();
+
+    s_following = true;
+    radio_retune(SN30_HOP_TABLE[s_slot.hop_idx]);
+
+    uint32_t deadline = s_slot.last_rx_us + s_slot.period_us + HOP_GUARD_US;
+    if ((int32_t)(deadline - now) < 0) deadline = now;   // already due
+    rf24g_hal_alarm_schedule(deadline, on_alarm);
+}
+
+// RAM-resident unsigned 32-bit divide, for handle_frame()'s period_us
+// update below ONLY. A variable-divisor `/` on a Cortex-M0+ (no hardware
+// divide instruction) compiles to a libcall, `__wrap___aeabi_uidiv` here,
+// and that symbol is flash-resident -- a call into it from the radio ISR is
+// exactly the kind of flash branch this file's header comment prohibits.
+// (Contrast RF24G_HIST_ADD's `dt_us / 1000` above: a CONSTANT divisor, which
+// the compiler turns into a multiply-shift with no libcall at all -- that
+// one needs no change.)
+//
+// This is a plain restoring shift-subtract divide: about 30 cycles for a
+// 32-bit quotient. Cost is a non-issue -- handle_frame() already spins for
+// ACK_GUARD_US (500us) on every frame, and this runs at the same ~100
+// times/s a linked controller delivers frames. Do NOT swap this for
+// pico-sdk's hardware divider (SIO on RP2040): this app also builds for
+// RP2350 (pico2/pico2_w), whose ARM cores have no SIO divide peripheral, and
+// the code must be identical on both. Do NOT put the `/` operator back
+// either, no matter how "obviously fine" it looks in a diff -- it isn't.
+static uint32_t __not_in_flash_func(rf24g_div_u32)(uint32_t num, uint32_t den)
+{
+    // den == 0 cannot happen at the one call site below -- burst_n is
+    // incremented before it is ever used as a divisor -- but this is ISR
+    // code, so guard it anyway rather than trust that invariant forever.
+    // Returning num (i.e. behaving like den==1) rather than 0 means a
+    // hypothetical hit here leaves period_us at a plausible large value
+    // instead of snapping it to 0, which would make schedule_next() treat
+    // the next arrival as already due and retune with no dwell at all.
+    if (den == 0) return num;
+
+    uint32_t quotient = 0;
+    for (int8_t bit = 31; bit >= 0; bit--) {
+        if ((num >> bit) >= den) {
+            num -= den << bit;
+            quotient |= (1u << bit);
+        }
+    }
+    return quotient;
+}
+
+// Decode + hand off a validated LINKED frame. Called only for frames that
+// have already passed the probe filter in on_radio_irq().
+static void __not_in_flash_func(handle_frame)(const uint8_t* buf, uint32_t now)
+{
+    rf24g_slot_t* s = &s_slot;
+    uint8_t ctr = buf[SN30_OFF_COUNTER];
+
+    s_seen = true;
+
+    s->pkts_total++;
+    s->pkts_window++;
+
+    bool was_linked = s->linked;
+    s->linked = true;
+    if (was_linked) s->confirmed = true;   // a SECOND good frame -- acquisition holds
+    s_state = RF24G_LINK_LINKED;
+
+    // Period estimate -- accumulate ONLY from consecutive (delta-counter==1)
+    // pairs; gap-spanning pairs skew it (see DWELL_US above).
+    if (was_linked) {
+        uint32_t dt = now - s->last_rx_us;
+        uint8_t  dc = (uint8_t)(ctr - s->last_ctr) & 0x3F;
+        if (dc == 1 && dt < 200000) {
+            s->burst_dt_us += dt;
+            s->burst_n++;
+            if (s->burst_n >= 100000) { s->burst_dt_us >>= 1; s->burst_n >>= 1; }
+            s->period_us = rf24g_div_u32(s->burst_dt_us, s->burst_n);
+        }
+        RF24G_HIST_ADD(s, dt);
+    }
+
+    s->last_ctr   = ctr;
+    s->last_rx_us = now;
+    s->hop_idx    = sn30_next_idx(ctr);
+    s->misses     = 0;
+
+    // Only a LINKED frame is real button state -- byte3 bit 0x20 (Start) is
+    // also the controller's power button and is set on most unlinked probe
+    // frames, so decoding an unlinked frame would report a phantom Start
+    // press every time a controller probes. See sn30_protocol.h.
+    ring_push(buf[SN30_OFF_BTN_LO], buf[SN30_OFF_BTN_HI]);
+
+    // Let the hardware auto-ACK finish before touching RF_CH. The ACK
+    // starts ~130us after the packet ends and is itself ~300us at 250kbps;
+    // retuning inside that window cuts it off, and the controller is
+    // waiting on exactly that ACK before it will start hopping. See
+    // ACK_GUARD_US.
+    uint32_t guard_deadline = now + ACK_GUARD_US;
+    while ((int32_t)(rf24g_hal_time_us() - guard_deadline) < 0) { /* spin */ }
+
+    schedule_next();
+}
+
+static void __not_in_flash_func(on_radio_irq)(void)
+{
+    if (s_state == RF24G_LINK_PAIRING) { pairing_on_rx_irq(); return; }
+
+    uint32_t now = rf24g_hal_time_us();
+
+    uint8_t last[SN30_PKT_LEN];
+    bool    got = false;
+
+    // Drain the FIFO (3 deep) and keep only the newest valid frame -- if
+    // something stalled us for a few ms, several frames may have queued and
+    // only the last one carries the current hop index.
+    for (uint8_t i = 0; i < 3; i++) {
+        if (nrf24_fifo_status() & NRF24_FIFO_RX_EMPTY) break;
+
+        uint8_t len = nrf24_r_rx_pl_wid();
+        if (len == 0 || len > NRF24_MAX_PAYLOAD) {
+            nrf24_flush_rx();   // corrupt length -- discard the lot
+            break;
+        }
+
+        uint8_t buf[NRF24_MAX_PAYLOAD];
+        uint8_t status = nrf24_r_rx_payload(buf, len);
+        uint8_t pipe = (uint8_t)((status & NRF24_STATUS_RX_P_NO_MASK) >> NRF24_STATUS_RX_P_NO_SHIFT);
+
+        // Do NOT validate byte 12 against 0x10 -- the contact frame that
+        // begins a link carries 0x31 there. Header + length + the 13-byte
+        // width are enough to identify a frame; see sn30_protocol.h.
+        if (len == SN30_PKT_LEN &&
+            buf[SN30_OFF_HEADER] == SN30_HDR_MAGIC &&
+            buf[SN30_OFF_LENGTH] == SN30_LEN_MAGIC &&
+            pipe == 0) {
+            // Byte loop, not memcpy: ISR context, and at -O0 a libc memcpy
+            // call would be flash-resident. See nrf24l01.c's nrf24_xfer().
+            for (uint8_t k = 0; k < SN30_PKT_LEN; k++) last[k] = buf[k];
+            got = true;
+        }
+    }
+
+    nrf24_write_reg(NRF24_REG_STATUS, NRF24_STATUS_RX_DR);
+
+    if (!got) return;
+
+    uint8_t ctr = last[SN30_OFF_COUNTER];
+
+    // Is this an unlinked probe rather than a genuine hop-sequence frame?
+    // A probe fails the hop_table[counter]==curCh identity, or carries the
+    // 0x31 trailer. Byte 10 free-runs (pinned at 48) while probing, so it is
+    // NOT a channel index yet -- following hop_table[48+1] walks away from
+    // the only channel a cold controller uses.
+    bool probe = !s_slot.linked &&
+                 (SN30_HOP_TABLE[ctr & 0x3F] != s_cur_ch ||
+                  last[SN30_OFF_TRAILER] == 0x31);
+
+    if (probe) {
+        s_slot.last_ctr = ctr;
+        if (s_state != RF24G_LINK_SEARCH) enter_search();
+        return;
+    }
+
+    handle_frame(last, now);
+}
+
+static void __not_in_flash_func(on_alarm)(void)
+{
+    if (s_state == RF24G_LINK_PAIRING) { pairing_on_alarm(); return; }
+
+    uint32_t now = rf24g_hal_time_us();
+
+    switch (s_state) {
+    case RF24G_LINK_PARK:
+        nrf24_set_channel(SN30_PARK_CH);
+        rf24g_hal_alarm_schedule(now + PARK_REARM_US, on_alarm);
+        break;
+
+    case RF24G_LINK_SEARCH:
+        s_sweep_idx = sn30_next_idx(s_sweep_idx);
+        radio_retune(SN30_HOP_TABLE[s_sweep_idx]);
+        if (++s_sweep_hops >= SEARCH_HOPS) {
+            enter_park();
+        } else {
+            rf24g_hal_alarm_schedule(now + DWELL_US, on_alarm);
+        }
+        break;
+
+    case RF24G_LINK_LINKED: {
+        if (!s_following) { enter_park(); break; }
+        rf24g_slot_t* s = &s_slot;
+        s->misses++;
+
+        bool give_up_to_search = !s->confirmed && s->misses > ACQUIRE_MISSES;
+        bool give_up_to_park   = s->misses > MAX_MISSES;
+
+        if (give_up_to_search || give_up_to_park) {
+            drop_slot_link();
+            if (give_up_to_search) enter_search(); else enter_park();
+            break;
+        }
+
+        // Free-run: advance this slot's index by one block-aware step and
+        // retune anyway, so a stall self-heals the moment a packet lands
+        // (every received frame re-syncs both index AND phase -- see
+        // handle_frame()).
+        s->hop_idx = sn30_next_idx(s->hop_idx);
+
+        // Advance the anchor by exactly one period -- NOT to `now`. `now` is
+        // the previous deadline, which already includes HOP_GUARD_US, so
+        // re-anchoring there slips the whole schedule HOP_GUARD_US later on
+        // every miss; after P/HOP_GUARD_US (7) consecutive misses the dwell
+        // no longer contains the transmitter's slot at all, and the link
+        // cannot re-sync until it coincides by luck. Keeping the anchor on
+        // the transmitter's own grid makes the free-run drift-free; a
+        // received frame still re-syncs index AND phase in handle_frame()
+        // exactly as before.
+        s->last_rx_us += s->period_us;
+
+        // Catch up in whole periods if a long stall (e.g. a flash sector
+        // erase, which runs with core-0 interrupts off) left the anchor more
+        // than one period behind, rather than letting schedule_next()'s
+        // `deadline = now` clamp spin the alarm at RF24G_ALARM_MIN_US
+        // intervals.
+        //
+        // BOUNDED, with a fallback, because this runs in alarm-ISR context
+        // where an unbounded loop is a hang and not merely a slowdown.
+        // period_us should never be 0 -- it is seeded to DWELL_US and only
+        // ever reassigned from rf24g_div_u32() -- but rf24g_div_u32() guards
+        // its own divisor for exactly the "don't trust that invariant
+        // forever" reason, and a 0 reaching here would spin this loop
+        // forever rather than just degrade a dwell. 8 periods is ~81ms,
+        // comfortably past the ~45ms worst-case flash_erase_sector() stall
+        // this exists to absorb.
+        for (uint8_t catchup = 0;
+             catchup < 8 && (int32_t)((s->last_rx_us + s->period_us) - now) < 0;
+             catchup++) {
+            s->last_rx_us += s->period_us;
+        }
+
+        // Still behind after the bound: a stall far longer than this
+        // arithmetic can absorb, or a degenerate period. Give up on holding
+        // the transmitter's grid and take the phase slip ONCE -- which is
+        // what the pre-fix code did on every single miss. The next received
+        // frame re-syncs both phase and index in handle_frame() regardless.
+        if ((int32_t)((s->last_rx_us + s->period_us) - now) < 0)
+            s->last_rx_us = now;
+
+        schedule_next();
+        break;
+    }
+
+    default:
+        break;
+    }
+}
+
+// ============================================================================
+// CORE-0 TASK -- ring drain, button decode, router submission
+// ============================================================================
+
+static void submit_event(uint8_t b2, uint8_t b3)
+{
+    uint32_t buttons = 0;
+
+    // Up sets a bit in BOTH bytes (byte2:0x80 and byte3:0x40 together) --
+    // treat either as Up, never surface byte3:0x40 as its own button.
+    if (sn30_up_pressed(b2, b3)) buttons |= JP_BUTTON_DU;
+    if (b2 & SN30_DOWN)  buttons |= JP_BUTTON_DD;
+    if (b2 & SN30_LEFT)  buttons |= JP_BUTTON_DL;
+    if (b2 & SN30_RIGHT) buttons |= JP_BUTTON_DR;
+
+    if (b2 & SN30_B) buttons |= JP_BUTTON_B1;
+    if (b2 & SN30_A) buttons |= JP_BUTTON_B2;
+    if (b2 & SN30_Y) buttons |= JP_BUTTON_B3;
+    if (b2 & SN30_X) buttons |= JP_BUTTON_B4;
+
+    if (b3 & SN30_L)      buttons |= JP_BUTTON_L1;
+    if (b3 & SN30_R)      buttons |= JP_BUTTON_R1;
+    if (b3 & SN30_SELECT) buttons |= JP_BUTTON_S1;
+    if (b3 & SN30_START)  buttons |= JP_BUTTON_S2;
+
+    input_event_t event;
+    init_input_event(&event);
+    event.dev_addr  = RF24G_DEV_ADDR;
+    event.instance  = 0;
+    event.type      = INPUT_TYPE_GAMEPAD;
+    event.transport = INPUT_TRANSPORT_NATIVE;
+    event.layout    = LAYOUT_NINTENDO_4FACE;
+    event.buttons   = buttons;
+    // No analog axes -- the SN30 2.4G has no sticks. init_input_event()
+    // already centred analog[] at 128.
+    router_submit_input(&event);
+}
+
+static void pairing_confirm_task(void)
+{
+    // Report the immediate outcome of the last pairing_end() call -- left
+    // there instead of printf'd directly since that runs in ISR/alarm
+    // context. "accepted" here just means the controller stopped asking,
+    // which is the offer going provisional, not confirmed -- see below.
+    pair_result_t result = s_pair_result;
+    if (result != PAIR_RESULT_NONE) {
+        s_pair_result = PAIR_RESULT_NONE;
+        if (result == PAIR_RESULT_ACCEPTED)
+            printf("[rf24g] pairing: paired -- confirming\n");
+        else
+            printf("[rf24g] pairing: not accepted\n");
+    }
+
+    if (!s_pair_prov_active || s_state == RF24G_LINK_PAIRING) return;
+
+    if (s_slot.pkts_total != s_pair_prov_pkts) {
+        s_pair_prov_active = false;
+        printf("[rf24g] pairing confirmed -- frames arriving\n");
+        return;
+    }
+
+    if ((int32_t)(rf24g_hal_time_us() - s_pair_prov_deadline_us) < 0) return;
+
+    // Diagnostic only -- see the comment by s_pair_prov_active's
+    // declaration. The pipe was already open before this pairing attempt
+    // and stays open regardless of whether it ever confirms.
+    //
+    // Report the OBSERVATION, not a cause. "No frames" has several causes
+    // that are indistinguishable from here, because they all look like
+    // silence to the radio: the controller rejected the offer; it already
+    // held this address and sat in pairing mode (which transmits no data
+    // frames) so its counter never moved; or it took the address but won't
+    // transmit until power-cycled. s_seen cannot disambiguate either: it is
+    // only set in handle_frame(), so in precisely this "no frames"
+    // situation it is still clear.
+    printf("[rf24g] pairing: no frames yet after %ums -- expected if this "
+           "controller was already paired here or is still in pairing "
+           "mode. Power-cycle the controller; if it still doesn't link, "
+           "pair again.\n",
+           (unsigned)(PAIR_CONFIRM_US / 1000));
+    s_pair_prov_active = false;
+}
+
+void rf24g_host_task(void)
+{
+    if (!s_initialized) return;
+
+    // Tear down the player registration the ISR flagged. Done here, on
+    // core 0, because remove_players_by_address() is flash-resident -- see
+    // s_unlink_pending.
+    if (s_unlink_pending) {
+        s_unlink_pending = false;
+        remove_players_by_address(RF24G_DEV_ADDR, 0);
+    }
+
+    while (s_ring_tail != s_ring_head) {
+        rf24g_rx_item_t item = s_ring[s_ring_tail];   // volatile struct copy
+        s_ring_tail = (uint8_t)((s_ring_tail + 1) & (RF24G_RING_SIZE - 1));
+        submit_event(item.raw_b2, item.raw_b3);
+    }
+
+    pairing_confirm_task();
+
+    uint32_t now_ms = platform_time_ms();
+    if ((uint32_t)(now_ms - s_stats_window_ms) >= 1000) {
+        s_slot.pps         = s_slot.pkts_window;
+        s_slot.pkts_window = 0;
+        s_stats_window_ms = now_ms;
+    }
+}
+
+// ============================================================================
+// PAIRING RENDEZVOUS -- driven from the same alarm/IRQ as the link
+// scheduler, dispatched on s_state == RF24G_LINK_PAIRING.
+// ============================================================================
+
+static void __not_in_flash_func(pairing_listen)(void)
+{
+    nrf24_flush_rx();
+    nrf24_flush_tx();
+    nrf24_write_reg_buf(NRF24_REG_RX_ADDR_P0, SN30_ADDR_P1, NRF24_ADDR_LEN);
+    nrf24_write_reg_buf(NRF24_REG_TX_ADDR,    SN30_ADDR_P1, NRF24_ADDR_LEN);
+    nrf24_write_reg(NRF24_REG_EN_RXADDR, 0x01);   // pipe 0 only while pairing
+    nrf24_set_channel(SN30_PARK_CH);
+    s_cur_ch = SN30_PARK_CH;
+    nrf24_power_up_rx();
+    rf24g_hal_ce(true);
+    nrf24_write_reg(NRF24_REG_STATUS,
+                     (uint8_t)(NRF24_STATUS_RX_DR | NRF24_STATUS_TX_DS | NRF24_STATUS_MAX_RT));
+}
+
+static void __not_in_flash_func(pairing_switch_tx)(void)
+{
+    nrf24_write_reg(NRF24_REG_EN_RXADDR, 0x00);   // not receiving while transmitting
+    nrf24_power_up_tx();
+}
+
+// ACK counts are not a reliable success signal here -- a run that
+// successfully bound a controller got nearly none of its replies
+// acknowledged. So this doesn't wait for TX_DS/MAX_RT; the 20ms slot
+// cadence is what the controller's listen window actually requires.
+static void __not_in_flash_func(pairing_send_reply)(void)
+{
+    nrf24_flush_tx();
+    nrf24_write_reg(NRF24_REG_STATUS,
+                     (uint8_t)(NRF24_STATUS_TX_DS | NRF24_STATUS_MAX_RT));
+    nrf24_w_tx_payload(s_pair_reply, SN30_PAIR_RSP_LEN);
+    rf24g_hal_ce(true);
+    uint32_t deadline = rf24g_hal_time_us() + 15;   // >=10us CE pulse triggers TX
+    while ((int32_t)(rf24g_hal_time_us() - deadline) < 0) { /* spin */ }
+    rf24g_hal_ce(false);
+}
+
+static void __not_in_flash_func(pairing_end)(bool claim)
+{
+    if (claim) {
+        // Start (or restart) the confirmation watch -- see the comment by
+        // s_pair_prov_active's declaration. No claim bookkeeping is needed
+        // here any more: the pipe has been open since boot regardless of
+        // the outcome, so this only decides what pairing_confirm_task()
+        // reports, not what the radio hears.
+        s_pair_prov_active      = true;
+        s_pair_prov_pkts        = s_slot.pkts_total;
+        s_pair_prov_deadline_us = rf24g_hal_time_us() + PAIR_CONFIRM_US;
+    }
+    s_pair_result = claim ? PAIR_RESULT_ACCEPTED : PAIR_RESULT_REJECTED;
+
+    // Restores the normal RX addresses / EN_RXADDR that pairing_listen() and
+    // pairing_switch_tx() overwrote for the rendezvous exchange -- needed
+    // whether or not `claim` is true, since the radio was reconfigured
+    // either way.
+    apply_pipe_addresses();
+    enter_park();
+}
+
+static void __not_in_flash_func(pairing_on_rx_irq)(void)
+{
+    uint16_t reqs = 0;
+
+    for (uint8_t i = 0; i < 3; i++) {
+        if (nrf24_fifo_status() & NRF24_FIFO_RX_EMPTY) break;
+        uint8_t len = nrf24_r_rx_pl_wid();
+        if (len == 0 || len > NRF24_MAX_PAYLOAD) { nrf24_flush_rx(); break; }
+        uint8_t buf[NRF24_MAX_PAYLOAD];
+        nrf24_r_rx_payload(buf, len);
+        if (len == SN30_PAIR_REQ_LEN && buf[0] == SN30_PAIR_HDR) reqs++;
+    }
+    nrf24_write_reg(NRF24_REG_STATUS, NRF24_STATUS_RX_DR);
+
+    if (!reqs) return;
+
+    uint32_t now = rf24g_hal_time_us();
+    s_pair_requests   += reqs;
+    s_pair_last_req_us = now;
+    if (s_pair_phase == PAIR_RX) s_pair_cycle_reqs += reqs;
+}
+
+static void __not_in_flash_func(pairing_on_alarm)(void)
+{
+    uint32_t now = rf24g_hal_time_us();
+
+    switch (s_pair_phase) {
+    case PAIR_WAIT:
+        if (s_pair_requests && (now - s_pair_last_req_us) >= PAIR_QUIET_US) {
+            // The controller burst-transmits its requests and only THEN
+            // listens -- answering the first request talks over the rest of
+            // its own burst while it is deaf to us. Wait for quiet, then
+            // hit the window the OEM dongle hits: first reply 346ms after
+            // the LAST request, never the first.
+            s_pair_phase = PAIR_TX;
+            s_pair_idx   = 0;
+            s_pair_cycle = 0;
+            pairing_switch_tx();
+            rf24g_hal_alarm_schedule(s_pair_last_req_us + PAIR_FIRST_TX_US, on_alarm);
+        } else if ((now - s_pair_started_us) >= PAIR_WAIT_US) {
+            pairing_end(false);
+        } else {
+            rf24g_hal_alarm_schedule(now + PAIR_POLL_US, on_alarm);
+        }
+        break;
+
+    case PAIR_TX:
+        pairing_send_reply();
+        if (++s_pair_idx >= PAIR_PER_CYCLE) {
+            s_pair_phase     = PAIR_RX;
+            s_pair_cycle_reqs = 0;
+            pairing_listen();
+            rf24g_hal_alarm_schedule(now + PAIR_LISTEN_US, on_alarm);
+        } else {
+            rf24g_hal_alarm_schedule(now + PAIR_SLOT_US, on_alarm);
+        }
+        break;
+
+    case PAIR_RX:
+        if (++s_pair_cycle >= PAIR_CYCLES) {
+            // Only the LAST cycle decides. A controller that accepts still
+            // re-requests once or twice first (both in our exchange and the
+            // dongle's own), so counting an earlier cycle's requests would
+            // call a successful pairing a failure.
+            pairing_end(s_pair_cycle_reqs == 0);
+        } else {
+            s_pair_phase = PAIR_TX;
+            s_pair_idx   = 0;
+            pairing_switch_tx();
+            rf24g_hal_alarm_schedule(now, on_alarm);
+        }
+        break;
+    }
+}
+
+bool rf24g_host_begin_pairing(void)
+{
+    if (!s_initialized || s_state == RF24G_LINK_PAIRING)
+        return false;
+
+    uint8_t addr[5];
+    sn30_identity(s_receiver_id, addr);
+    sn30_pair_reply(addr, s_pair_reply);
+
+    s_pair_phase        = PAIR_WAIT;
+    s_pair_cycle        = 0;
+    s_pair_idx          = 0;
+    s_pair_requests     = 0;
+    s_pair_cycle_reqs   = 0;
+    s_pair_last_req_us  = platform_time_us();
+    s_pair_started_us   = platform_time_us();
+    s_state = RF24G_LINK_PAIRING;
+
+    pairing_listen();
+
+    printf("[rf24g] pairing: offering %02X %02X %02X %02X %02X -- "
+           "hold Select on a controller until its LED blinks rapidly\n",
+           addr[0], addr[1], addr[2], addr[3], addr[4]);
+
+    rf24g_hal_alarm_schedule(platform_time_us() + PAIR_POLL_US, on_alarm);
+    return true;
+}
+
+bool rf24g_host_is_pairing(void)
+{
+    return s_state == RF24G_LINK_PAIRING;
+}
+
+// ============================================================================
+// PUBLIC API
+// ============================================================================
+
+void rf24g_host_init(void)
+{
+    rf24g_host_init_pins(RF24G_PIN_SCK, RF24G_PIN_MOSI, RF24G_PIN_MISO,
+                         RF24G_PIN_CSN, RF24G_PIN_CE, RF24G_PIN_IRQ);
+}
+
+void rf24g_host_init_pins(uint8_t sck, uint8_t mosi, uint8_t miso,
+                          uint8_t csn, uint8_t ce, uint8_t irq)
+{
+    if (s_initialized) return;
+
+    printf("[rf24g] init SCK=%d MOSI=%d MISO=%d CSN=%d CE=%d IRQ=%d\n",
+           sck, mosi, miso, csn, ce, irq);
+
+    memset(&s_slot, 0, sizeof(s_slot));
+    s_slot.period_us = DWELL_US;
+
+    // Derive this receiver's permanent identity from the board's own
+    // factory-programmed unique ID -- see sn30_protocol.h's "Receiver
+    // identity" and s_receiver_id's declaration above. Flash-resident and
+    // core-0-only, which is safe here (this runs once at init, before
+    // radio_init() below and before rf24g_hal_irq_attach() further down --
+    // the ISR chain isn't live yet) but must never be called from anywhere
+    // reachable from on_radio_irq()/on_alarm(), since platform_get_unique_id()
+    // performs a flash operation on RP2040.
+    uint8_t uid[8];
+    platform_get_unique_id(uid, sizeof(uid));
+    sn30_derive_receiver_id(uid, sizeof(uid), s_receiver_id);
+    printf("[rf24g] receiver id %02X %02X %02X %02X (derived from board unique id)\n",
+           s_receiver_id[0], s_receiver_id[1], s_receiver_id[2], s_receiver_id[3]);
+
+    rf24g_hal_init(sck, mosi, miso, csn, ce, irq);
+
+    if (!nrf24_probe()) {
+        printf("[rf24g] WARNING: nRF24L01+ not responding -- check wiring "
+               "(SPI/CE/CSN) and power-cycle the module, not just the board\n");
+    }
+
+    radio_init();
+    rf24g_hal_irq_attach(on_radio_irq);
+
+    s_initialized = true;
+    enter_park();
+
+    printf("[rf24g] parked on ch %u (%u MHz), nothing seen yet\n",
+           SN30_PARK_CH, 2400 + SN30_PARK_CH);
+}
+
+bool rf24g_host_is_connected(void)
+{
+    return s_initialized && s_slot.linked;
+}
+
+uint8_t rf24g_host_get_device_count(void)
+{
+    return s_slot.linked ? 1 : 0;
+}
+
+const char* rf24g_host_state_name(void)
+{
+    switch (s_state) {
+        case RF24G_LINK_LINKED:  return "LINKED";
+        case RF24G_LINK_SEARCH:  return "SEARCH";
+        case RF24G_LINK_PAIRING: return "PAIRING";
+        default:                 return "PARK";
+    }
+}
+
+void rf24g_host_print_stats(void)
+{
+    printf("[rf24g] state=%s ch=%u (%u MHz)\n",
+           rf24g_host_state_name(), s_cur_ch, 2400 + s_cur_ch);
+
+    if (!s_seen && s_slot.pkts_total == 0) return;
+
+    printf("[rf24g]  %-6s seen=%s pps=%lu total=%lu period=%luus misses=%u\n",
+           s_slot.linked ? "LINKED" : "-", s_seen ? "yes" : "no",
+           (unsigned long)s_slot.pps, (unsigned long)s_slot.pkts_total,
+           (unsigned long)s_slot.period_us, s_slot.misses);
+    printf("[rf24g]    inter-arrival(ms): <8=%u 8-9=%u 9-11=%u 11-13=%u "
+           "13-20=%u >=20=%u\n",
+           s_slot.inter_hist[0], s_slot.inter_hist[1], s_slot.inter_hist[2],
+           s_slot.inter_hist[3], s_slot.inter_hist[4], s_slot.inter_hist[5]);
+}
+
+const InputInterface rf24g_input_interface = {
+    .name = "24G",
+    .source = INPUT_SOURCE_NATIVE_24G,
+    .init = rf24g_host_init,
+    .task = rf24g_host_task,
+    .is_connected = rf24g_host_is_connected,
+    .get_device_count = rf24g_host_get_device_count,
+};

--- a/src/native/host/rf24g/rf24g_host.h
+++ b/src/native/host/rf24g/rf24g_host.h
@@ -1,0 +1,91 @@
+// rf24g_host.h - SN30 2.4G wireless dongle emulation, native host driver
+//
+// Drives an nRF24L01+ over SPI to impersonate the 8BitDo SN30 2.4G dongle
+// well enough that SN30 2.4G controllers pair and link to it, and presents
+// them to the router as native gamepad input. Protocol details (radio
+// config, hop table, framing, pairing rendezvous) are ground truth
+// recovered by a logic-analyser tap on an original dongle -- see
+// sn30_protocol.h.
+//
+// Physical: nRF24L01+ module on spi0, exactly one paired controller, on
+// nRF24 pipe 0. The receiver's own identity is derived from the board's
+// unique ID rather than persisted to flash -- it comes out the same on
+// every boot by construction, so pairing survives a reboot or reflash of
+// the same board but not a move to a different one.
+//
+// Supports exactly one controller by design: USB output only ever surfaces
+// player index 0 (see app.h's USB_OUTPUT_PORTS), and two controllers
+// sharing the same 64-entry hop table at independent phase can starve each
+// other's dwell indefinitely if they power on close in phase.
+
+#ifndef RF24G_HOST_H
+#define RF24G_HOST_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "core/input_interface.h"
+
+// dev_addr this driver owns. 0xC0/0xD0/0xE0/0xF0 are already claimed by
+// other native hosts (Wii, GC/UART, N64/3DO/PSX/Jaguar, SNES/LodgeNet/PCE
+// respectively).
+#define RF24G_DEV_ADDR 0xB0
+
+// Default GPIO pins (can be overridden by app.h before #include). Clear of
+// GP23/24/25/29, which the CYW43 module claims on _w boards. SCK/MOSI/MISO
+// are spi0's native pinout -- see rf24g_hal_rp2040.c.
+#ifndef RF24G_PIN_MISO
+#define RF24G_PIN_MISO 0
+#endif
+#ifndef RF24G_PIN_CE
+#define RF24G_PIN_CE 4
+#endif
+#ifndef RF24G_PIN_CSN
+#define RF24G_PIN_CSN 5
+#endif
+#ifndef RF24G_PIN_SCK
+#define RF24G_PIN_SCK 6
+#endif
+#ifndef RF24G_PIN_MOSI
+#define RF24G_PIN_MOSI 7
+#endif
+#ifndef RF24G_PIN_IRQ
+#define RF24G_PIN_IRQ 8
+#endif
+
+// Initialize with the default pins above.
+void rf24g_host_init(void);
+
+// Initialize with a custom pin set.
+void rf24g_host_init_pins(uint8_t sck, uint8_t mosi, uint8_t miso,
+                          uint8_t csn, uint8_t ce, uint8_t irq);
+
+// Core-0 task: drains decoded button events and submits them to the router,
+// confirms/rolls back a provisional pairing claim, and updates per-second
+// stats. Does NO radio I/O -- the radio runs entirely off interrupts, see
+// rf24g_host.c's file header.
+void rf24g_host_task(void);
+
+// True if the controller is currently linked.
+bool rf24g_host_is_connected(void);
+
+// 1 if the controller is currently linked, 0 otherwise.
+uint8_t rf24g_host_get_device_count(void);
+
+// Begin the pairing rendezvous, offering the receiver's identity to
+// whichever controller is held in pairing mode (Select ~3s, LED blinking
+// rapidly). Returns false if a pairing attempt is already in progress.
+bool rf24g_host_begin_pairing(void);
+
+// True while a pairing rendezvous is in progress.
+bool rf24g_host_is_pairing(void);
+
+// Current link state, for diagnostics ("PARK", "SEARCH", "LINKED", "PAIRING").
+const char* rf24g_host_state_name(void);
+
+// printf diagnostics: link state, current channel, and the linked
+// controller's packets/sec + inter-arrival histogram.
+void rf24g_host_print_stats(void);
+
+extern const InputInterface rf24g_input_interface;
+
+#endif // RF24G_HOST_H

--- a/src/native/host/rf24g/sn30_protocol.h
+++ b/src/native/host/rf24g/sn30_protocol.h
@@ -3,7 +3,8 @@
 // Every value here was recovered from a logic-analyser tap on the SPI bus
 // between the original 8BitDo receiver's MCU and its radio. They are
 // ground truth read off real register writes, not inference -- do not
-// "fix" them.
+// "fix" them. Full capture notes and reverse-engineering detail:
+// https://github.com/FatBeard/sf30-2.4g-protocol
 //
 // Deliberately free of pico-sdk / platform calls -- see rf24g_hal.h. Only
 // rf24g_host.c includes this file, and it must include rf24g_hal.h first

--- a/src/native/host/rf24g/sn30_protocol.h
+++ b/src/native/host/rf24g/sn30_protocol.h
@@ -1,0 +1,275 @@
+// sn30_protocol.h - SN30 2.4G RF protocol constants
+//
+// Every value here was recovered from a logic-analyser tap on the SPI bus
+// between the original 8BitDo receiver's MCU and its radio. They are
+// ground truth read off real register writes, not inference -- do not
+// "fix" them.
+//
+// Deliberately free of pico-sdk / platform calls -- see rf24g_hal.h. Only
+// rf24g_host.c includes this file, and it must include rf24g_hal.h first
+// (see rf24g_host.c's include block) so __not_in_flash_func is defined
+// before sn30_identity()/sn30_next_idx() below use it: both are called from
+// rf24g_host.c's ISR/alarm chain (sn30_identity() via apply_pipe_addresses()
+// <- pairing_end() <- on_alarm(); sn30_next_idx() from handle_frame()/
+// on_radio_irq()/on_alarm()/enter_search()), and `static inline` alone is
+// only ever a hint -- nothing guarantees the compiler actually inlines
+// either one at every call site (a lower optimization level, e.g. debug
+// builds, is enough to break that assumption), so both need the same
+// RAM-residency guarantee as everything else reachable from that chain --
+// see rf24g_host.c's file header.
+
+#ifndef SN30_PROTOCOL_H
+#define SN30_PROTOCOL_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stddef.h>
+
+// ---- Radio ---------------------------------------------------------- */
+
+// RX_ADDR_P0 / TX_ADDR, in bus order (nRF24 multi-byte registers are
+// LSByte-first). The OEM dongle's own link address -- unused by this driver
+// (we always assign a receiver-owned identity, see "Receiver identity"
+// below) but kept for a future OEM-address diagnostic mode.
+static const uint8_t SN30_ADDR[5] = { 0xE4, 0x81, 0x00, 0xEA, 0xB3 };
+
+// The pairing rendezvous address (see "Pairing rendezvous" below) -- pipe 1
+// on the OEM dongle.
+static const uint8_t SN30_ADDR_P1[5] = { 0xE4, 0x17, 0xD8, 0x55, 0xAA };
+
+// Idle/unpaired park channel: RF_CH 0x2F = 2447 MHz. Deliberately chosen by
+// the original firmware because it is itself a hop channel (indices 2, 29,
+// 33 and 62), so a controller that is running the sequence is guaranteed to
+// visit it.
+#define SN30_PARK_CH 0x2F
+
+// 16 channels over a 64-step sequence, exact period, no drift.
+//   RF_CH = SN30_HOP_TABLE[index];  freq = 2400 + RF_CH MHz
+static const uint8_t SN30_HOP_TABLE[64] = {
+      6,  24,  47,  67,  11,  29,  51,  69,
+     14,  33,  55,  73,  17,  36,  59,  76,
+     76,  59,  36,  17,  73,  55,  33,  14,
+     69,  51,  29,  11,  67,  47,  24,   6,
+     67,  47,  24,   6,  69,  51,  29,  11,
+     73,  55,  33,  14,  76,  59,  36,  17,
+     17,  36,  59,  76,  14,  33,  55,  73,
+     11,  29,  51,  69,   6,  24,  47,  67,
+};
+
+// ---- Receiver identity --------------------------------------------------
+//
+// Pairing hands the controller whatever address the receiver offers -- see
+// "Pairing rendezvous" below. A replacement receiver can therefore be given
+// an address of its own, which is the only way to tell two of them apart:
+// on the OEM address they are indistinguishable, same pipe, same framing.
+//
+// The address's LSByte (0xE4) is fixed; the remaining four bytes are a
+// receiver ID, PERMANENT and never persisted -- computed by
+// sn30_derive_receiver_id() below from the board's own factory-programmed
+// unique ID, so it comes out identical on every boot with nothing written
+// to flash and nothing to lose on a power cycle. This mirrors the OEM
+// dongle itself -- its address is burned in at the factory, permanent and
+// unique per unit, and pairing writes it into the CONTROLLER's memory,
+// never the receiver's. Reflashing the same board keeps the controller
+// paired to it; moving to a different board changes the receiver ID (a
+// different unique ID hashes differently) and requires re-pairing, exactly
+// like swapping in a different physical OEM dongle would.
+#define SN30_IDENT_LSB 0xE4
+
+// Fallback receiver ID for a degenerate sn30_derive_receiver_id() result
+// (see below). Not a "factory default" in the OEM sense -- every board
+// computes its own permanent ID -- this is only reached on the rare hash
+// collision with a reserved address (an all-equal result, or one that
+// aliases SN30_ADDR_P1 or SN30_ADDR's own upper bytes).
+static const uint8_t SN30_IDENT_BODY[4] = { 0x5A, 0x31, 0xC7, 0x92 };
+
+// Builds the receiver's address under receiver ID `body`, in bus order,
+// into 5 bytes.
+//
+// Called from apply_pipe_addresses() (rf24g_host.c), which is reachable
+// from on_alarm() via pairing_end() during pairing, so this has to stay off
+// any flash-resident libc call. Four EXPLICIT scalar stores, not a loop: a
+// `for` loop here, even with a compile-time-constant trip count, is fair
+// game for GCC's tree-loop-distribute-patterns pass, which can turn it back
+// into a runtime memcpy() call -- confirmed by disassembly to happen on the
+// RP2040 (Cortex-M0+) build even though the equivalent loop built clean on
+// RP2350. Do not "clean this up" into a loop or memcpy call without
+// re-checking disassembly on both targets.
+static inline void __not_in_flash_func(sn30_identity)(const uint8_t *body, uint8_t *out)
+{
+    out[0] = SN30_IDENT_LSB;
+    out[1] = body[0];
+    out[2] = body[1];
+    out[3] = body[2];
+    out[4] = body[3];
+}
+
+// FNV-1a over the whole board uid, into a 4-byte receiver ID.
+//
+// Hashing all `len` bytes rather than truncating to 4 matters: RP2040
+// boards from one production reel commonly share a flash-ID prefix (the
+// vendor/lot fields are the high-order bytes), so a naive truncation could
+// hand two boards off the same reel the same receiver ID. FNV-1a mixes
+// every input byte into every output byte, so a shared prefix alone isn't
+// enough to collide.
+//
+// Three results are degenerate and get remapped to SN30_IDENT_BODY instead
+// of being used as-is:
+//   - all four output bytes equal (covers 00 00 00 00 and FF FF FF FF --
+//     what you get if platform_get_unique_id() ever reads back a flash
+//     chip that isn't answering the ID command)
+//   - 17 D8 55 AA -- SN30_ADDR_P1's own upper bytes; the receiver's link
+//     address would alias the pairing rendezvous address itself
+//   - 81 00 EA B3 -- SN30_ADDR's own upper bytes, the OEM dongle's body
+// Both aliasing cases are pathological (any real 64-bit flash ID landing
+// on either exact value is astronomically unlikely), but they're cheap to
+// guard against and the failure mode -- a receiver indistinguishable from
+// the pairing channel or the dongle it's replacing -- is bad enough that
+// it's worth being paranoid here.
+static inline void sn30_derive_receiver_id(const uint8_t *uid, size_t len, uint8_t *out4)
+{
+    uint32_t hash = 0x811c9dc5u;   // FNV-1a 32-bit offset basis
+    for (size_t i = 0; i < len; i++) {
+        hash ^= uid[i];
+        hash *= 0x01000193u;       // FNV-1a 32-bit prime
+    }
+    out4[0] = (uint8_t)(hash >> 24);
+    out4[1] = (uint8_t)(hash >> 16);
+    out4[2] = (uint8_t)(hash >> 8);
+    out4[3] = (uint8_t)(hash);
+
+    bool all_equal = (out4[0] == out4[1]) && (out4[1] == out4[2]) && (out4[2] == out4[3]);
+    bool aliases_p1  = memcmp(out4, SN30_ADDR_P1 + 1, 4) == 0;
+    bool aliases_oem = memcmp(out4, SN30_ADDR + 1, 4) == 0;
+    if (all_equal || aliases_p1 || aliases_oem) {
+        memcpy(out4, SN30_IDENT_BODY, 4);
+    }
+}
+
+// ---- Pairing rendezvous -------------------------------------------------
+//
+// Request   (controller -> receiver, 4 bytes):  35 04 00 <counter8>
+// Response  (receiver -> controller, 13 bytes): 35 0D 01 <addr> <~addr>
+//
+// Bytes 8-12 are the one's complement of the offered address -- the captured
+// pair E4 81 00 EA B3 / 1B 7E FF 15 4C XORs to FF on all five bytes. They are
+// a check field bound to the address, not a receiver ID, so an offer of a
+// DIFFERENT address must recompute them. Copying the dongle's tail verbatim
+// alongside a different address makes every reply invalid by construction.
+//
+// The rendezvous address is SN30_ADDR_P1 and the channel is SN30_PARK_CH;
+// RF_CH is never written for the duration of the exchange.
+#define SN30_PAIR_HDR      0x35
+#define SN30_PAIR_REQ      0x00   /* byte 2: message type, request  */
+#define SN30_PAIR_RSP      0x01   /* byte 2: message type, response */
+#define SN30_PAIR_REQ_LEN  4
+#define SN30_PAIR_RSP_LEN  13
+
+static inline void sn30_pair_reply(const uint8_t *addr, uint8_t *out13)
+{
+    out13[0] = SN30_PAIR_HDR;
+    out13[1] = SN30_PAIR_RSP_LEN;
+    out13[2] = SN30_PAIR_RSP;
+    for (uint8_t i = 0; i < 5; i++) {
+        out13[3 + i] = addr[i];
+        out13[8 + i] = addr[i] ^ 0xFF;
+    }
+}
+
+// ---- Packet framing -------------------------------------------------
+//
+//   80 0D <b2> <b3> 00 00 80 80 80 80 <idx> <cyc> 10   <- at rest
+//    0  1   2    3   4  5  6  7  8  9   10    11   12
+#define SN30_PKT_LEN      13
+#define SN30_OFF_HEADER    0   /* 0x80 constant */
+#define SN30_OFF_LENGTH    1   /* 0x0D constant (13) */
+#define SN30_OFF_BTN_LO    2   /* d-pad + face buttons */
+#define SN30_OFF_BTN_HI    3   /* L/R/Select/Start + Up's second bit */
+#define SN30_OFF_COUNTER  10   /* hop index, 0x00-0x3F -- NOT a plain counter */
+#define SN30_OFF_CYCLE    11   /* <base> | (counter >> 4), base is NOT constant */
+#define SN30_OFF_TRAILER  12   /* 0x10 constant, but 0x31 on the contact frame */
+
+#define SN30_CYCLE_MASK   0x03 /* the only bits of byte 11 that are understood */
+
+#define SN30_HDR_MAGIC  0x80
+#define SN30_LEN_MAGIC  0x0D
+#define SN30_TRL_MAGIC  0x10
+
+// ---- The frame counter, and why byte 10 is not it -----------------------
+//
+// Byte 10 does NOT run 0->63 and wrap. It runs in 16-frame blocks, and the
+// blocks come in a fixed non-ascending order:
+//
+//     32..47, 48..63, 16..31, 0..15, 32..47, ...
+//
+// so there are exactly three non-`+1` transitions in every 64 frames:
+// 63->16, 15->32 and 31->0.
+//
+// The true frame counter is monotonic and lives across both bytes:
+//
+//     counter = ((byte11 & 3) << 4) | (byte10 & 0x0F)
+//
+// which steps by exactly +1 on nearly all adjacent pairs (the rare
+// exception a +2 where the source capture itself dropped a frame). So byte
+// 11's low two bits are the counter's HIGH two bits, and byte 10 is the same
+// counter with its high two bits permuted -- that permutation being the hop
+// index.
+//
+// Consequence: `index + 1` is the wrong successor three times in every 64
+// hops, and because both sides then advance by one the error PERSISTS
+// rather than self-correcting -- measured a >1.5x throughput hit on real
+// hardware. Use sn30_next_idx().
+//
+// The upper six bits of byte 11 are a separate open question. Do not
+// decode them.
+
+// Block order 2 -> 3 -> 1 -> 0 -> 2, indexed by the current block.
+static inline uint8_t __not_in_flash_func(sn30_next_idx)(uint8_t idx)
+{
+    static const uint8_t NEXT_BLK[4] = { 2, 0, 3, 1 };
+    idx &= 0x3F;
+    return ((idx & 0x0F) != 0x0F) ? (uint8_t)(idx + 1)
+                                  : (uint8_t)(NEXT_BLK[idx >> 4] << 4);
+}
+
+// ---- Button bits ----------------------------------------------------- */
+// Combinations are a plain bitwise OR -- no interlocks, no SOCD handling, no
+// special diagonal encoding. Bytes 4-5 are unused; 6-9 are constant 0x80.
+
+// byte 2
+#define SN30_UP     0x80
+#define SN30_DOWN   0x40
+#define SN30_LEFT   0x20
+#define SN30_RIGHT  0x10
+#define SN30_A      0x08
+#define SN30_B      0x04
+#define SN30_X      0x02
+#define SN30_Y      0x01
+
+// byte 3
+#define SN30_UP2    0x40   /* set together with SN30_UP -- see quirk below */
+#define SN30_START  0x20
+#define SN30_SELECT 0x10
+#define SN30_R      0x08
+#define SN30_L      0x01
+
+// Quirk: pressing Up sets byte2:0x80 AND byte3:0x40 together. byte3:0x40 has
+// never been observed without byte2:0x80, and stayed clear through both the
+// A/B/X/Y and L/R/Select/Start rotations, so it is not a mis-attributed
+// shoulder or Select/Start bit. Deterministic but unexplained. Treat either
+// bit as Up; never surface SN30_UP2 as a button of its own.
+static inline bool sn30_up_pressed(uint8_t b2, uint8_t b3)
+{
+    return (b2 & SN30_UP) || (b3 & SN30_UP2);
+}
+
+// Bits 1, 2 and 7 of byte 3 were never observed set.
+
+// byte3:0x20 (Start) is ALSO the controller's power button, so it is set on
+// most unlinked probe frames (power-on/power-off both hold it). A decoder
+// must gate button decoding on the link being established -- see
+// rf24g_host.c's `probe` handling -- or it reports a phantom Start press
+// every time an unlinked controller probes.
+
+#endif /* SN30_PROTOCOL_H */


### PR DESCRIPTION
## Summary
- New `24g2usb` app drives an nRF24L01+ over SPI, impersonating the 8BitDo SN30 2.4G's OEM USB dongle closely enough that controllers pair and cold-link directly — no 8BitDo dongle needed.
- Interrupt-driven radio (IRQ line + hardware alarm, not the main polling loop) so other core-0 work can't stall a dwell and drop a packet. Receiver identity is derived from the board's unique ID rather than persisted to flash.
- Supports exactly one controller by design (USB output only ever surfaces a single player; two controllers hopping the same table can starve each other's dwell). Hold BOOTSEL ~1.5s to pair. Boards: Pico 2 W, Pico W, Pico, Pico 2.
- Protocol details recovered by logic-analyser capture of the OEM dongle's SPI bus — see [docs/apps/24g2usb.md](docs/apps/24g2usb.md), [docs/input/24g.md](docs/input/24g.md), [docs/protocols/24g.md](docs/protocols/24g.md), and the full capture notes at https://github.com/FatBeard/sf30-2.4g-protocol.

## Test plan
- [x] `make 24g2usb_pico` and `make 24g2usb_pico2` build clean
- [x] Flashed to a real Pico 2 (RP2350); paired an SN30 2.4G controller and confirmed correct button input via a USB gamepad tester