### PR TITLE
fix(controller): use incremental display flush so button presses don'…

### DIFF
--- a/src/apps/controller/app.c
+++ b/src/apps/controller/app.c
@@ -271,6 +271,9 @@ void app_init(void)
             .pin_rst = pad_config->display_rst,
         };
         display_init(&disp_cfg);
+        // Async: display_update() marks dirty and returns; app_task() pushes
+        // one page per iteration so no single iteration blocks on the transfer.
+        display_set_async(true);
         printf("[app:controller] Display initialized\n");
     }
 
@@ -450,6 +453,10 @@ void app_task(void)
 {
     // Process button input for mode switching
     button_task();
+
+    // Push at most one display page per iteration (no-op when nothing is
+    // pending), so the OLED transfer never blocks the input path.
+    display_flush_step();
 
     // Update LED colors when USB output mode changes (skip when peer controls LEDs)
 #ifdef I2C_PEER_ENABLED


### PR DESCRIPTION
`display_flush_step()` and `display_set_async()` are implemented but never called anywhere in `src/`, so `display_update()` always takes the synchronous `display_flush()` path.

In the controller app, `display_marquee_tick()` returns true at ~50fps while the marquee scrolls, and each of those ticks calls `display_update()`. On a build with an OLED that's a full blocking frame transfer per tick — the ~57ms you mention in the comment on `display_flush_step()` — and it's triggered by the button press that added the marquee entry in the first place.

This enables async mode at display init and pumps one page per iteration from `app_task()`. Visible behaviour is the same; the transfer is spread across 8 iterations (16 on rotated SH1107 panels) rather than blocking one.

Scoped to the controller app only — I didn't want to change the default for every app that calls `display_update()` and expects it to have painted by the time it returns. Happy to move it into `display_init()` if you'd rather it applied everywhere.

Not compile-tested locally (didn't have the submodules and toolchain set up), so I'm relying on CI here. Two lines of actual change.